### PR TITLE
Remove local dev commands that do not use build sumodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,21 +95,6 @@ run: $(KUBECTL) generate
 	@$(KUBECTL) apply -f config/crd/ -R
 	go run cmd/provider/main.go -d
 
-dev: $(KIND) $(KUBECTL)
-	@$(INFO) Creating kind cluster
-	@$(KIND) create cluster --name=provider-gcp-dev
-	@$(KUBECTL) cluster-info --context kind-provider-gcp-dev
-	@$(INFO) Installing Crossplane CRDs
-	@$(KUBECTL) apply -k https://github.com/crossplane/crossplane//cluster?ref=master
-	@$(INFO) Installing Provider GCP CRDs
-	@$(KUBECTL) apply -f $(CRD_DIR) -R
-	@$(INFO) Starting Provider GCP controllers
-	@$(GO) run cmd/provider/main.go --debug
-
-dev-clean: $(KIND) $(KUBECTL)
-	@$(INFO) Deleting kind cluster
-	@$(KIND) delete cluster --name=provider-gcp-dev
-
 # ====================================================================================
 # Package related targets
 
@@ -148,4 +133,4 @@ clean-package:
 manifests:
 	@$(INFO) Deprecated. Run make generate instead.
 
-.PHONY: cobertura reviewable submodules fallthrough run clean-package build-package manifests dev dev-clean
+.PHONY: cobertura reviewable submodules fallthrough run clean-package build-package manifests


### PR DESCRIPTION
Now that the build submodule handles starting a local dev env we should
remove the commands that provide similar functionality without it.

These also look like they were using `provider-gcp` anyway :)

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>