### PR TITLE
Configure upbound-bot git user in tag action

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -7,6 +7,10 @@ on:
         description: 'Release version (e.g. v0.1.0)'
         required: true
 
+env:
+  UPBOUND_BOT_USR: ${{ secrets.UPBOUND_BOT_USR }}
+  UPBOUND_BOT_PSW: ${{ secrets.UPBOUND_BOT_PSW }}
+
 jobs:
   create-tag:
     runs-on: ubuntu-18.04
@@ -19,6 +23,13 @@ jobs:
 
       - name: Fetch History
         run: git fetch --prune --unshallow
+
+      - name: Configure Git User
+        run:  |
+          git config --global credential.helper cache
+          git config remote.origin.url https://${UPBOUND_BOT_USR}:${UPBOUND_BOT_PSW}@\$(git config --get remote.origin.url | sed -e 's/https:\\/\\///')
+          git config user.name "upbound-bot"
+          git config user.email "info@crossplane.io"
 
       - name: Create Tag
         run: make -j2 tag


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Configures the upbound-bot git user in the tag action before calling
make tag which assumes an already configured git user.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Closely mimics behavior here: https://github.com/crossplane/crossplane/blob/f220ea959420af58ee0bcdcf9ad709fcbfc72ad3/Jenkinsfile.tag#L20

It appears to me that the[`GITHUB_TOKEN`](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token) permissions do not allow for tagging, but there are some actions that appear to use it, so it is possible this could be improved.

[contribution process]: https://git.io/fj2m9
