### PR TITLE
Preserve unknown fields in Helm values

### DIFF
--- a/apis/release/v1alpha1/types.go
+++ b/apis/release/v1alpha1/types.go
@@ -60,6 +60,7 @@ type SetVal struct {
 
 // ValuesSpec defines the Helm value overrides spec for a Release
 type ValuesSpec struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Values     runtime.RawExtension `json:"values,omitempty"`
 	ValuesFrom []ValueFromSource    `json:"valuesFrom,omitempty"`
 	Set        []SetVal             `json:"set,omitempty"`

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -181,6 +181,7 @@ spec:
                     type: array
                   values:
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   valuesFrom:
                     items:
                       description: ValueFromSource represents source of a value


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Preserve unknown fields in Helm values.
Otherwise the values will be dropped by the API as all its fields are unknown (no schema). This behavior changed with the v1 CRD introduced in #65 .

See also: https://github.com/crossplane/crossplane/blob/master/apis/apiextensions/v1beta1/composition_types.go#L85


<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Manually on a cluster.

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
