### PR TITLE
update the in-composition definition to v1 spec

### DIFF
--- a/examples/in-composition/cluster.yaml
+++ b/examples/in-composition/cluster.yaml
@@ -3,4 +3,4 @@ kind: WordpressCluster
 metadata:
   name: mycluster
 spec:
-  clusterVersion: 1.15.12-gke.16
+  clusterVersion: "1.18"

--- a/examples/in-composition/definition.yaml
+++ b/examples/in-composition/definition.yaml
@@ -1,30 +1,30 @@
-apiVersion: apiextensions.crossplane.io/v1alpha1
+apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
   name: wordpressclusters.example.crossplane.io
 spec:
-  defaultComposition:
-   name: wordpressclusters.example.crossplane.io
   connectionSecretKeys:
     - kubeconfig
-  crdSpecTemplate:
-    group: example.crossplane.io
-    version: v1alpha1
-    names:
-      kind: WordpressCluster
-      listKind: WordpressClusterList
-      plural: wordpressclusters
-      singular: wordpresscluster
-    validation:
-      openAPIV3Schema:
-        description: A WordpressCluster is a composite resource that represents a K8S Cluster with Wordpress Installed
-        type: object
-        properties:
-          spec:
-            type: object
-            properties:
-              clusterVersion:
-                type: string
-                description: GKE cluster version
-            required:
-              - clusterVersion
+  group: example.crossplane.io
+  names:
+    kind: WordpressCluster
+    listKind: WordpressClusterList
+    plural: wordpressclusters
+    singular: wordpresscluster
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          description: A WordpressCluster is a composite resource that represents a K8S Cluster with Wordpress Installed
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                clusterVersion:
+                  type: string
+                  description: GKE cluster version
+              required:
+                - clusterVersion


### PR DESCRIPTION
Signed-off-by: Eric Charles <eric@datalayer.io>

### Description of your changes

This update the definition of the wordpresscluster example to `apiextensions.crossplane.io/v1` - The current `apiextensions.crossplane.io/v1alph1` is no more available with the latest crossplane release.

The schema of the yaml has changes, so `examples/in-composition/definition.yaml` is updated accordingly.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review. -> NA

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
I have successfully tested on my local env deploying a GKE cluster and having the wordpress UI available.

[contribution process]: https://git.io/fj2m9
