### PR TITLE
Add WaitTimeout field

### DIFF
--- a/apis/release/v1beta1/types.go
+++ b/apis/release/v1beta1/types.go
@@ -82,6 +82,9 @@ type ReleaseParameters struct {
 	SkipCreateNamespace bool `json:"skipCreateNamespace,omitempty"`
 	// Wait for the release to become ready.
 	Wait bool `json:"wait,omitempty"`
+	// WaitTimeout is the duration Helm will wait for the release to become
+	// ready. Only applies if wait is also set. Defaults to 5m.
+	WaitTimeout *metav1.Duration `json:"waitTimeout,omitempty"`
 	// PatchesFrom describe patches to be applied to the rendered manifests.
 	PatchesFrom []ValueFromSource `json:"patchesFrom,omitempty"`
 	// ValuesSpec defines the Helm value overrides spec for a Release.

--- a/apis/release/v1beta1/zz_generated.deepcopy.go
+++ b/apis/release/v1beta1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -165,6 +166,11 @@ func (in *ReleaseObservation) DeepCopy() *ReleaseObservation {
 func (in *ReleaseParameters) DeepCopyInto(out *ReleaseParameters) {
 	*out = *in
 	out.Chart = in.Chart
+	if in.WaitTimeout != nil {
+		in, out := &in.WaitTimeout, &out.WaitTimeout
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	if in.PatchesFrom != nil {
 		in, out := &in.PatchesFrom, &out.PatchesFrom
 		*out = make([]ValueFromSource, len(*in))

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -619,6 +619,11 @@ spec:
                   wait:
                     description: Wait for the release to become ready.
                     type: boolean
+                  waitTimeout:
+                    description: WaitTimeout is the duration Helm will wait for the
+                      release to become ready. Only applies if wait is also set. Defaults
+                      to 5m.
+                    type: string
                 required:
                 - chart
                 - namespace

--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -24,6 +24,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/pkg/errors"
@@ -73,7 +74,7 @@ type client struct {
 }
 
 // NewClient returns a new Helm Client with provided config
-func NewClient(log logging.Logger, config *rest.Config, namespace string, wait bool) (Client, error) {
+func NewClient(log logging.Logger, config *rest.Config, namespace string, wait bool, timeout time.Duration) (Client, error) {
 	rg := newRESTClientGetter(config, namespace)
 
 	actionConfig := new(action.Configuration)
@@ -101,14 +102,17 @@ func NewClient(log logging.Logger, config *rest.Config, namespace string, wait b
 	ic := action.NewInstall(actionConfig)
 	ic.Namespace = namespace
 	ic.Wait = wait
+	ic.Timeout = timeout
 
 	uc := action.NewUpgrade(actionConfig)
 	uc.Wait = wait
+	uc.Timeout = timeout
 
 	uic := action.NewUninstall(actionConfig)
 
 	rb := action.NewRollback(actionConfig)
 	rb.Wait = wait
+	rb.Timeout = timeout
 
 	return &client{
 		log:             log,

--- a/pkg/controller/release/release.go
+++ b/pkg/controller/release/release.go
@@ -53,6 +53,8 @@ const (
 	resyncPeriod     = 10 * time.Minute
 	reconcileTimeout = 10 * time.Minute
 
+	defaultWaitTimeout = 5 * time.Minute
+
 	helmReleaseNameAnnotation      = "meta.helm.sh/release-name"
 	helmReleaseNamespaceAnnotation = "meta.helm.sh/release-namespace"
 	helmNamespaceLabel             = "app.kubernetes.io/managed-by"
@@ -119,7 +121,7 @@ type connector struct {
 	usage           resource.Tracker
 	newRestConfigFn func(kubeconfig []byte) (*rest.Config, error)
 	newKubeClientFn func(config *rest.Config) (client.Client, error)
-	newHelmClientFn func(log logging.Logger, config *rest.Config, namespace string, wait bool) (helmClient.Client, error)
+	newHelmClientFn func(log logging.Logger, config *rest.Config, namespace string, wait bool, timeout time.Duration) (helmClient.Client, error)
 }
 
 func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.ExternalClient, error) {
@@ -184,7 +186,7 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 		return nil, errors.Wrap(err, errNewKubernetesClient)
 	}
 
-	h, err := c.newHelmClientFn(c.logger, rc, cr.Spec.ForProvider.Namespace, cr.Spec.ForProvider.Wait)
+	h, err := c.newHelmClientFn(c.logger, rc, cr.Spec.ForProvider.Namespace, cr.Spec.ForProvider.Wait, waitTimeout(cr))
 	if err != nil {
 		return nil, errors.Wrap(err, errNewKubernetesClient)
 	}
@@ -403,4 +405,11 @@ func (e *helmExternal) createNamespace(ctx context.Context, name string) error {
 		},
 	}
 	return e.kube.Create(ctx, ns)
+}
+
+func waitTimeout(cr *v1beta1.Release) time.Duration {
+	if cr.Spec.ForProvider.WaitTimeout != nil {
+		return cr.Spec.ForProvider.WaitTimeout.Duration
+	}
+	return defaultWaitTimeout
 }

--- a/pkg/controller/release/release_test.go
+++ b/pkg/controller/release/release_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
@@ -145,7 +146,7 @@ func Test_connector_Connect(t *testing.T) {
 		client          client.Client
 		newRestConfigFn func(kubeconfig []byte) (*rest.Config, error)
 		newKubeClientFn func(config *rest.Config) (client.Client, error)
-		newHelmClientFn func(log logging.Logger, config *rest.Config, namespace string, wait bool) (helmClient.Client, error)
+		newHelmClientFn func(log logging.Logger, config *rest.Config, namespace string, wait bool, timeout time.Duration) (helmClient.Client, error)
 		usage           resource.Tracker
 		mg              resource.Managed
 	}
@@ -332,7 +333,7 @@ func Test_connector_Connect(t *testing.T) {
 				newKubeClientFn: func(config *rest.Config) (c client.Client, err error) {
 					return &test.MockClient{}, nil
 				},
-				newHelmClientFn: func(log logging.Logger, config *rest.Config, namespace string, wait bool) (h helmClient.Client, err error) {
+				newHelmClientFn: func(log logging.Logger, config *rest.Config, namespace string, wait bool, timeout time.Duration) (h helmClient.Client, err error) {
 					return &MockHelmClient{}, nil
 				},
 				usage: resource.TrackerFn(func(ctx context.Context, mg resource.Managed) error { return nil }),


### PR DESCRIPTION
### Description of your changes

This adds a new field `WaitTimeout` that specifies the timeout for the
helm client actions. If not set it will fall back to a default value in
order to fix #103.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
