### PR TITLE
fix(readme): changed provider apiVersion to v1 since crossplane 1.0.0…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ kubectl crossplane install provider crossplane/provider-helm:master
 You may also manually install `provider-helm` by creating a `Provider` directly:
 
 ```yaml
-apiVersion: pkg.crossplane.io/v1alpha1
+apiVersion: pkg.crossplane.io/v1
 kind: Provider
 metadata:
   name: provider-helm


### PR DESCRIPTION


Signed-off-by: haarchri <chhaar30@googlemail.com>

### Description of your changes
changed readme
since crossplane 1.0.0… alphav1 is dropped

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

N/A

[contribution process]: https://git.io/fj2m9
