### PR TITLE
Add support for OCI charts

### DIFF
--- a/apis/release/v1beta1/types.go
+++ b/apis/release/v1beta1/types.go
@@ -91,6 +91,8 @@ type ReleaseParameters struct {
 	ValuesSpec `json:",inline"`
 	// SkipCRDs skips installation of CRDs for the release.
 	SkipCRDs bool `json:"skipCRDs,omitempty"`
+	// InsecureSkipTLSVerify skips tls certificate checks for the chart download
+	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/examples/sample/release-oci.yaml
+++ b/examples/sample/release-oci.yaml
@@ -7,12 +7,12 @@ spec:
   forProvider:
     chart:
       name: wordpress
-      repository: https://charts.bitnami.com/bitnami
+      repository: "oci://localhost:5000/helm-charts"
       version: 9.3.19
 #     pullSecretRef:
-#       name: museum-creds
+#       name: oci-creds
 #       namespace: default
-#     url: "https://charts.bitnami.com/bitnami/wordpress-9.3.19.tgz"
+#     url: "oci://localhost:5000/helm-charts/wordpress:9.3.19"
     namespace: wordpress
 #   insecureSkipTLSVerify: true
 #   skipCreateNamespace: true

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -481,6 +481,10 @@ spec:
                           latest version if not set
                         type: string
                     type: object
+                  insecureSkipTLSVerify:
+                    description: InsecureSkipTLSVerify skips tls certificate checks
+                      for the chart download
+                    type: boolean
                   namespace:
                     description: Namespace to install the release into.
                     type: string

--- a/pkg/clients/helm/args.go
+++ b/pkg/clients/helm/args.go
@@ -12,4 +12,6 @@ type Args struct {
 	Timeout time.Duration
 	// SkipCRDs skips CRDs creation during Helm release install or upgrade.
 	SkipCRDs bool
+	// InsecureSkipTLSVerify skips tls certificate checks for the chart download
+	InsecureSkipTLSVerify bool
 }

--- a/pkg/controller/release/release.go
+++ b/pkg/controller/release/release.go
@@ -136,6 +136,7 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		config.Wait = cr.Spec.ForProvider.Wait
 		config.Timeout = waitTimeout(cr)
 		config.SkipCRDs = cr.Spec.ForProvider.SkipCRDs
+		config.InsecureSkipTLSVerify = cr.Spec.ForProvider.InsecureSkipTLSVerify
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
This pull request aims to add support for pulling helm charts from OCI registries. 

In addition, the pull request also adds support for pulling charts from insecure registries by adding the option `insecureSkipTLSVerify` to the Release manifest

Since helm 3.8.0 needed some newer dependencies I decided to include a dependency upgrade in this PR as well. If it is preferable to have them as separate pull requests I can split them.

### Open questions:
* ~How should we handle insecure registries?~
* ~Should we also add support for defining the url option with `oci://` prefixed protocol? And if that is the case, should we require it to define the full tar file path?  Or support the url to be defined as `oci://localhost:5000/myrepo/mychart:2.7.0`~ 
 
Fixes #75 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Following manual tests have been performed:
* `repository` option set to a `oci://` url and also tests with version option set and without version option set.
* `url` option set to a `oci://` url with and without `:<tag>` suffix
* with and without hitting the cache

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
