### PR TITLE
Set config home in Dockerfile

### DIFF
--- a/cluster/images/provider-helm-controller/Dockerfile
+++ b/cluster/images/provider-helm-controller/Dockerfile
@@ -4,6 +4,7 @@ RUN apk --no-cache add ca-certificates bash
 ADD provider /usr/local/bin/crossplane-helm-provider
 
 ENV XDG_CACHE_HOME /tmp
+ENV XDG_CONFIG_HOME /tmp
 
 EXPOSE 8080
 USER 1001

--- a/cluster/integration/integration_tests.sh
+++ b/cluster/integration/integration_tests.sh
@@ -135,15 +135,15 @@ EOF
 )"
 echo "${PVC_YAML}" | "${KUBECTL}" create -f -
 
-# install crossplane from master channel
-echo_step "installing crossplane from master channel"
-"${HELM3}" repo add crossplane-master https://charts.crossplane.io/master/
-chart_version="$("${HELM3}" search repo crossplane-master/crossplane --devel | awk 'FNR == 2 {print $2}')"
+# install crossplane from stable channel
+echo_step "installing crossplane from stable channel"
+"${HELM3}" repo add crossplane-stable https://charts.crossplane.io/stable/
+chart_version="$("${HELM3}" search repo crossplane-stable/crossplane | awk 'FNR == 2 {print $2}')"
 echo_info "using crossplane version ${chart_version}"
 echo
 # we replace empty dir with our PVC so that the /cache dir in the kind node
 # container is exposed to the crossplane pod
-"${HELM3}" install crossplane --namespace crossplane-system crossplane-master/crossplane --version ${chart_version} --devel --set packageCache.pvc=package-cache
+"${HELM3}" install crossplane --namespace crossplane-system crossplane-stable/crossplane --version ${chart_version} --set packageCache.pvc=package-cache
 
 echo_step "waiting for deployment crossplane rollout to finish"
 "${KUBECTL}" -n "${CROSSPLANE_NAMESPACE}" rollout status "deploy/crossplane" --timeout=2m


### PR DESCRIPTION
Signed-off-by: Mathias Åhsberg <mathias.ahsberg@resurs.se>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

When deploying a helm chart from an OCI registry with credentials the Release will fail with the following error:

> Warning  CannotCreateExternalResource  4s (x16 over 54s)  managed/release.helm.crossplane.io  failed to install release: failed to login to registry: mkdir /.config: permission denied

It is raised when Helm is trying to create the config folder to be used for storing auth details for the registry. 

By setting the `XDG_CONFIG_HOME ` to the `/tmp` folder in the Dockerfile we can be sure that the user running the container has permission to create the required folders.

See https://github.com/helm/helm/issues/8038 for a related issue

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

The PR has now been verified with installing a helm chart from a secured ECR registry in local cluster. Without the patch it will fail with the described behaviour. With the patch the Helm chart can be installed successfully.

[contribution process]: https://git.io/fj2m9
