### PR TITLE
Drop doc.crds.dev link as content is viewed alongside docs now

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -15,9 +15,6 @@ metadata:
       management of [Helm](https://helm.sh) Releases on Kubernetes clusters
       typically provisioned by Crossplane.
 
-      Available resources and their fields can be found in the [CRD
-      Docs](https://doc.crds.dev/github.com/crossplane-contrib/provider-helm).
-
       If you encounter an issue please reach out on
       [slack.crossplane.io](https://slack.crossplane.io) and create an issue in
       the


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Drops the doc.crds.dev link now that content is automatically shown in marketplace.upbound.io when new versions are pushed.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Verified updated content renders correctly.

[contribution process]: https://git.io/fj2m9
