### PR TITLE
Add dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Add dependabot configuration for dependency management

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
This configuration works in the provider-terraform repository.

[contribution process]: https://git.io/fj2m9
