### PR TITLE
Optionally skip 'partOfRelease' check

### DIFF
--- a/apis/release/v1beta1/types.go
+++ b/apis/release/v1beta1/types.go
@@ -124,6 +124,8 @@ type ReleaseStatus struct {
 type ConnectionDetail struct {
 	v1.ObjectReference    `json:",inline"`
 	ToConnectionSecretKey string `json:"toConnectionSecretKey,omitempty"`
+	// SkipPartOfReleaseCheck skips check for meta.helm.sh/release-name annotation.
+	SkipPartOfReleaseCheck bool `json:"skipPartOfReleaseCheck,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/examples/sample/release-oci.yaml
+++ b/examples/sample/release-oci.yaml
@@ -55,6 +55,14 @@ spec:
 #      namespace: wordpress
 #      fieldPath: data.wordpress-password
 #      toConnectionSecretKey: password
+#    - apiVersion: v1
+#      kind: Secret
+#      name: manual-api-secret
+#      namespace: wordpress
+#      fieldPath: data.api-key
+#      toConnectionSecretKey: api-key
+#      # this secret created manually (not via Helm chart), so skip 'part of helm release' check
+#      skipPartOfReleaseCheck: true
 #  writeConnectionSecretToRef:
 #    name: wordpress-credentials
 #    namespace: crossplane-system

--- a/examples/sample/release.yaml
+++ b/examples/sample/release.yaml
@@ -55,6 +55,14 @@ spec:
 #      namespace: wordpress
 #      fieldPath: data.wordpress-password
 #      toConnectionSecretKey: password
+#    - apiVersion: v1
+#      kind: Secret
+#      name: manual-api-secret
+#      namespace: wordpress
+#      fieldPath: data.api-key
+#      toConnectionSecretKey: api-key
+#      # this secret created manually (not via Helm chart), so skip 'part of helm release' check
+#      skipPartOfReleaseCheck: true
 #  writeConnectionSecretToRef:
 #    name: wordpress-credentials
 #    namespace: crossplane-system

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -555,6 +555,10 @@ spec:
                       description: 'Specific resourceVersion to which this reference
                         is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                       type: string
+                    skipPartOfReleaseCheck:
+                      description: SkipPartOfReleaseCheck skips check for meta.helm.sh/release-name
+                        annotation.
+                      type: boolean
                     toConnectionSecretKey:
                       type: string
                     uid:

--- a/pkg/controller/release/observe.go
+++ b/pkg/controller/release/observe.go
@@ -134,8 +134,7 @@ func connectionDetails(ctx context.Context, kube client.Client, connDetails []v1
 			return mcd, errors.Wrap(err, "cannot get object")
 		}
 
-		// TODO(hasan): consider making this check configurable, i.e. possible to skip via a field in spec
-		if !partOfRelease(ro, relName, relNamespace) {
+		if !cd.SkipPartOfReleaseCheck && !partOfRelease(ro, relName, relNamespace) {
 			return mcd, errors.Errorf(errObjectNotPartOfRelease, cd.ObjectReference)
 		}
 

--- a/pkg/controller/release/observe_test.go
+++ b/pkg/controller/release/observe_test.go
@@ -475,7 +475,48 @@ func Test_connectionDetails(t *testing.T) {
 				},
 			},
 		},
+
+		"Success_NotPartOfReleaseAndSkipPartOfReleaseCheck": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						if o, ok := obj.(*unstructured.Unstructured); o.GetKind() == "Secret" && ok && key.Name == testSecretName && key.Namespace == testNamespace {
+							*obj.(*unstructured.Unstructured) = unstructured.Unstructured{
+								Object: map[string]interface{}{
+									"data": map[string]interface{}{
+										"db-password": "MTIzNDU=",
+									},
+								},
+							}
+						}
+						return nil
+					},
+				},
+
+				connDetails: []v1beta1.ConnectionDetail{
+					{
+						ObjectReference: corev1.ObjectReference{
+							Kind:       "Secret",
+							Namespace:  testNamespace,
+							Name:       testSecretName,
+							APIVersion: "v1",
+							FieldPath:  "data.db-password",
+						},
+						ToConnectionSecretKey: "password",
+						SkipPartOfReleaseCheck: true,
+					},
+				},
+				relName:      testReleaseName,
+				relNamespace: testNamespace,
+			},
+			want: want{
+				out: managed.ConnectionDetails{
+					"password": []byte("12345"),
+				},
+			},
+		},
 	}
+
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			got, gotErr := connectionDetails(context.Background(), tc.args.kube, tc.args.connDetails, tc.args.relName, tc.args.relNamespace)

--- a/pkg/controller/release/observe_test.go
+++ b/pkg/controller/release/observe_test.go
@@ -502,7 +502,7 @@ func Test_connectionDetails(t *testing.T) {
 							APIVersion: "v1",
 							FieldPath:  "data.db-password",
 						},
-						ToConnectionSecretKey: "password",
+						ToConnectionSecretKey:  "password",
 						SkipPartOfReleaseCheck: true,
 					},
 				},


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
Add ability to skip 'is part of release' check for manually (non-helm managed) created resource when generating ConnectionDetails.

PS. Field **skipPartOfReleaseCheck** added to _ConnectionDetail_ struct instead of _ReleaseParameters_ (which makes more sense IMHO) because there is we cannot (or can but I'm do not know how? :-) ) access _ReleaseParameters_ from _connectionDetails_ function.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #99 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Added 'Success_NotPartOfReleaseAndSkipPartOfReleaseCheck' test to observe_test.go.

[contribution process]: https://git.io/fj2m9
