### PR TITLE
Configure higher burst limit to avoid client side throttling

### DIFF
--- a/pkg/clients/helm/restclientgetter.go
+++ b/pkg/clients/helm/restclientgetter.go
@@ -50,7 +50,8 @@ func (c *restClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterfa
 	// The more groups you have, the more discovery requests you need to make.
 	// given 25 groups (our groups + a few custom conf) with one-ish version each, discovery needs to make 50 requests
 	// double it just so we don't end up here again for a while.  This config is only used for discovery.
-	config.Burst = 100
+	// Align value with https://github.com/kubernetes/kubernetes/pull/109141
+	config.Burst = 300
 
 	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(config)
 	return memory.NewMemCacheClient(discoveryClient), nil


### PR DESCRIPTION
* Fixes #159

* No more client-side throttling timeouts like

```
I1128 12:44:10.336621       1 request.go:665] Waited for 11.188964474s due to client-side throttling, not priority and fairness, request: GET:https://10.255.0.1:443/apis/cloudidentity.cnrm.cloud.google.com/v1beta1?timeout=32s
I1128 12:44:20.345096       1 request.go:665] Waited for 5.989111872s due to client-side throttling, not priority and fairness, request: GET:https://10.255.0.1:443/apis/binaryauthorization.cnrm.cloud.google.com/v1beta1?timeout=32s
I1128 12:44:31.086707       1 request.go:665] Waited for 1.174828735s due to client-side throttling, not priority and fairness, request: GET:https://10.255.0.1:443/apis/servicedirectory.cnrm.cloud.google.com/v1beta1?timeout=32s
```

* 300 value is aligned with associated kubectl fix at https://github.com/kubernetes/kubernetes/pull/109141

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

By running provider locally with `make run` against cluster with 842 CRD and reconciling over one Release MR

A value of 100 continuously provided client-throttling errors

A value of 300 produces clean logs without client-side throttling timeouts 

[contribution process]: https://git.io/fj2m9
