### PR TITLE
Add Proxy Support

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -33,6 +33,10 @@ type ProviderConfigSpec struct {
 	// example by configuring a bearer token source such as OAuth.
 	// +optional
 	Identity *Identity `json:"identity,omitempty"`
+
+	// Proxy used to connect to the Kubernetes API.
+	// +optional
+	Proxy string `json:"proxy,omitempty"`
 }
 
 // ProviderCredentials required to authenticate.

--- a/apis/v1beta1/types.go
+++ b/apis/v1beta1/types.go
@@ -33,6 +33,10 @@ type ProviderConfigSpec struct {
 	// example by configuring a bearer token source such as OAuth.
 	// +optional
 	Identity *Identity `json:"identity,omitempty"`
+
+	// Proxy used to connect to the Kubernetes API.
+	// +optional
+	Proxy string `json:"proxy,omitempty"`
 }
 
 // ProviderCredentials required to authenticate.

--- a/package/crds/helm.crossplane.io_providerconfigs.yaml
+++ b/package/crds/helm.crossplane.io_providerconfigs.yaml
@@ -163,6 +163,9 @@ spec:
                 - source
                 - type
                 type: object
+              proxy:
+                description: Proxy used to connect to the Kubernetes API.
+                type: string
             required:
             - credentials
             type: object
@@ -358,6 +361,9 @@ spec:
                 - source
                 - type
                 type: object
+              proxy:
+                description: Proxy used to connect to the Kubernetes API.
+                type: string
             required:
             - credentials
             type: object

--- a/pkg/controller/release/release.go
+++ b/pkg/controller/release/release.go
@@ -18,6 +18,8 @@ package release
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
@@ -80,6 +82,7 @@ const (
 	errFailedToSetName                  = "failed to update chart spec with the name from URL"
 	errFailedToSetVersion               = "failed to update chart spec with the latest version"
 	errFailedToCreateNamespace          = "failed to create namespace for release"
+	errFailedToParseProxy               = "failed to parse proxy url"
 )
 
 // Setup adds a controller that reconciles Release managed resources.
@@ -200,6 +203,14 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 				return nil, errors.Wrap(err, errFailedToInjectGoogleCredentials)
 			}
 		}
+	}
+
+	if proxy := p.Spec.Proxy; proxy != "" {
+		u, err := url.Parse(proxy)
+		if err != nil {
+			return nil, errors.Wrap(err, errFailedToParseProxy)
+		}
+		rc.Proxy = http.ProxyURL(u)
 	}
 
 	k, err := c.newKubeClientFn(rc)


### PR DESCRIPTION
### Description of your changes

Adds a proxy support for connecting to the Kubernetes API server.

Fixes #195

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested it manually by installing a helm chart via a proxy.

[contribution process]: https://git.io/fj2m9
