### PR TITLE
Adding support for managementPolicies (fixes #209)

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -50,6 +50,8 @@ func main() {
 		syncInterval     = app.Flag("sync", "How often all resources will be double-checked for drift from the desired state.").Short('s').Default("1h").Duration()
 		pollInterval     = app.Flag("poll", "How often individual resources will be checked for drift from the desired state").Default("10m").Duration()
 		maxReconcileRate = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("100").Int()
+
+		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -94,6 +96,11 @@ func main() {
 		PollInterval:            *pollInterval,
 		GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
 		Features:                &feature.Flags{},
+	}
+
+	if *enableManagementPolicies {
+		o.Features.Enable(feature.EnableBetaManagementPolicies)
+		log.Info("Beta feature enabled", "flag", feature.EnableBetaManagementPolicies)
 	}
 
 	kingpin.FatalIfError(template.Setup(mgr, o, *timeout), "Cannot setup Template controllers")

--- a/pkg/controller/release/observe.go
+++ b/pkg/controller/release/observe.go
@@ -61,7 +61,7 @@ func generateObservation(in *release.Release) v1beta1.ReleaseObservation {
 }
 
 // isUpToDate checks whether desired spec up to date with the observed state for a given release
-func isUpToDate(ctx context.Context, kube client.Client, managementPoliciesEnabled bool, spec *v1beta1.ReleaseSpec, observed *release.Release, s v1beta1.ReleaseStatus) (bool, error) { // nolint:gocyclo
+func isUpToDate(ctx context.Context, kube client.Client, spec *v1beta1.ReleaseSpec, observed *release.Release, s v1beta1.ReleaseStatus) (bool, error) { // nolint:gocyclo
 	if observed.Info == nil {
 		return false, errors.New(errReleaseInfoNilInObservedRelease)
 	}
@@ -88,7 +88,7 @@ func isUpToDate(ctx context.Context, kube client.Client, managementPoliciesEnabl
 
 	mp := sets.New[xpv1.ManagementAction](spec.ManagementPolicies...)
 
-	if managementPoliciesEnabled && len(mp) != 0 && !mp.HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionAll) {
+	if len(mp) != 0 && !mp.HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionAll) {
 		// Treated as up-to-date as we don't update or create the resource
 		return true, nil
 	}

--- a/pkg/controller/release/observe.go
+++ b/pkg/controller/release/observe.go
@@ -61,7 +61,7 @@ func generateObservation(in *release.Release) v1beta1.ReleaseObservation {
 }
 
 // isUpToDate checks whether desired spec up to date with the observed state for a given release
-func isUpToDate(ctx context.Context, kube client.Client, spec *v1beta1.ReleaseSpec, observed *release.Release, s v1beta1.ReleaseStatus) (bool, error) { // nolint:gocyclo
+func isUpToDate(ctx context.Context, kube client.Client, managementPoliciesEnabled bool, spec *v1beta1.ReleaseSpec, observed *release.Release, s v1beta1.ReleaseStatus) (bool, error) { // nolint:gocyclo
 	if observed.Info == nil {
 		return false, errors.New(errReleaseInfoNilInObservedRelease)
 	}
@@ -88,7 +88,7 @@ func isUpToDate(ctx context.Context, kube client.Client, spec *v1beta1.ReleaseSp
 
 	mp := sets.New[xpv1.ManagementAction](spec.ManagementPolicies...)
 
-	if len(mp) != 0 && !mp.HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionAll) {
+	if managementPoliciesEnabled && len(mp) != 0 && !mp.HasAny(xpv1.ManagementActionUpdate, xpv1.ManagementActionAll) {
 		// Treated as up-to-date as we don't update or create the resource
 		return true, nil
 	}

--- a/pkg/controller/release/release.go
+++ b/pkg/controller/release/release.go
@@ -94,18 +94,17 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 
 	reconcilerOptions := []managed.ReconcilerOption{
 		managed.WithExternalConnecter(&connector{
-			client:                    mgr.GetClient(),
-			logger:                    o.Logger,
-			usage:                     resource.NewProviderConfigUsageTracker(mgr.GetClient(), &helmv1beta1.ProviderConfigUsage{}),
-			managementPoliciesEnabled: o.Features.Enabled(feature.EnableBetaManagementPolicies),
-			kcfgExtractorFn:           resource.CommonCredentialExtractor,
-			gcpExtractorFn:            resource.CommonCredentialExtractor,
-			gcpInjectorFn:             gke.WrapRESTConfig,
-			azureExtractorFn:          resource.CommonCredentialExtractor,
-			azureInjectorFn:           azure.WrapRESTConfig,
-			newRestConfigFn:           clients.NewRESTConfig,
-			newKubeClientFn:           clients.NewKubeClient,
-			newHelmClientFn:           helmClient.NewClient,
+			client:           mgr.GetClient(),
+			logger:           o.Logger,
+			usage:            resource.NewProviderConfigUsageTracker(mgr.GetClient(), &helmv1beta1.ProviderConfigUsage{}),
+			kcfgExtractorFn:  resource.CommonCredentialExtractor,
+			gcpExtractorFn:   resource.CommonCredentialExtractor,
+			gcpInjectorFn:    gke.WrapRESTConfig,
+			azureExtractorFn: resource.CommonCredentialExtractor,
+			azureInjectorFn:  azure.WrapRESTConfig,
+			newRestConfigFn:  clients.NewRESTConfig,
+			newKubeClientFn:  clients.NewKubeClient,
+			newHelmClientFn:  helmClient.NewClient,
 		}),
 		managed.WithPollInterval(o.PollInterval),
 		managed.WithLogger(o.Logger.WithValues("controller", name)),
@@ -131,10 +130,9 @@ func Setup(mgr ctrl.Manager, o controller.Options, timeout time.Duration) error 
 }
 
 type connector struct {
-	logger                    logging.Logger
-	client                    client.Client
-	usage                     resource.Tracker
-	managementPoliciesEnabled bool
+	logger logging.Logger
+	client client.Client
+	usage  resource.Tracker
 
 	kcfgExtractorFn  func(ctx context.Context, src xpv1.CredentialsSource, c client.Client, ccs xpv1.CommonCredentialSelectors) ([]byte, error)
 	gcpExtractorFn   func(ctx context.Context, src xpv1.CredentialsSource, c client.Client, ccs xpv1.CommonCredentialSelectors) ([]byte, error)
@@ -253,22 +251,20 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 	}
 
 	return &helmExternal{
-		logger:                    l,
-		localKube:                 c.client,
-		kube:                      k,
-		helm:                      h,
-		patch:                     newPatcher(),
-		managementPoliciesEnabled: c.managementPoliciesEnabled,
+		logger:    l,
+		localKube: c.client,
+		kube:      k,
+		helm:      h,
+		patch:     newPatcher(),
 	}, nil
 }
 
 type helmExternal struct {
-	logger                    logging.Logger
-	localKube                 client.Client
-	kube                      client.Client
-	helm                      helmClient.Client
-	patch                     Patcher
-	managementPoliciesEnabled bool
+	logger    logging.Logger
+	localKube client.Client
+	kube      client.Client
+	helm      helmClient.Client
+	patch     Patcher
 }
 
 func (e *helmExternal) Observe(ctx context.Context, mg resource.Managed) (managed.ExternalObservation, error) {
@@ -305,7 +301,7 @@ func (e *helmExternal) Observe(ctx context.Context, mg resource.Managed) (manage
 		return managed.ExternalObservation{ResourceExists: true}, nil
 	}
 
-	s, err := isUpToDate(ctx, e.localKube, e.managementPoliciesEnabled, &cr.Spec, rel, cr.Status)
+	s, err := isUpToDate(ctx, e.localKube, &cr.Spec, rel, cr.Status)
 	if err != nil {
 		return managed.ExternalObservation{}, errors.Wrap(err, errFailedToCheckIfUpToDate)
 	}


### PR DESCRIPTION
### Description of your changes

This PR is adding support for Management Policies that allows to install a Helm chart and ignore any changes to it and still have healthy managed resource. This is useful if you want to perform the initial installation of the Helm chart via Crossplane (e.g. during bootstrap of a cluster) but later want to manage it via GitOps tool (e.g. ArgoCD or FluxCD).  If the Helm chart is uninstalled via GitOps or via Helm chart client, Crossplane will make sure the chart is installed again.

Fixes #209

I have:

- [x] Read and followed Crossplane's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I have build the image and tested it on a local K3D cluster with different sets of `managementPolicies`. If `managementPolicies: [Create, Delete, Observe]`, I can change the version and/or the values of the Helm chart and Crossplane doesn't reinstall it and still keeps the managed resource healthy. If I add `Update` or set it to `*`, the Helm chart is reinstalled by Crossplane if the version and/or values change. See my comment below for more details.