### PR TITLE
Add OWNERS.md file with current maintainers

### DIFF
--- a/OWNERS.md
+++ b/OWNERS.md
@@ -1,0 +1,16 @@
+# OWNERS
+
+This page lists all maintainers for **this** repository. Each repository in the
+[Crossplane organization](https://github.com/crossplane/) will list their
+repository maintainers in their own `OWNERS.md` file.
+
+Please see the Crossplane
+[GOVERNANCE.md](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md)
+for governance guidelines and responsibilities for the steering committee and
+maintainers.
+
+## Maintainers
+
+* Hasan Turken <hasan@upbound.io> ([turkenh](https://github.com/turkenh))
+* Lovro Sviben <lovro.sviben@upbound.io> ([lsviben](https://github.com/lsviben)) 
+* Erhan Cagirici <erhan@upbound.io> ([erhancagirici](https://github.com/erhancagirici))


### PR DESCRIPTION
### Description of your changes

This PR simply adds an OWNERS.md file with the current set of contributors that have maintainer permissions. This will make it easier for new contributors to understand who is a maintainer in this repo.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.


[contribution process]: https://git.io/fj2m9
