### PR TITLE
consume golangci-lint 1.61.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = https://github.com/upbound/build
+	url = https://github.com/crossplane/build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,14 @@
-run:
-  deadline: 10m
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: CC0-1.0
 
-  skip-files:
-    - "zz_\\..+\\.go$"
+run:
+  timeout: 10m
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats:
+    - format: colored-line-number
 
 linters-settings:
   errcheck:
@@ -18,10 +20,10 @@ linters-settings:
     # default is false: such cases aren't reported by default.
     check-blank: false
 
-    # [deprecated] comma-separated list of pairs of the form pkg:regex
-    # the regex is used to ignore names within pkg. (default "fmt:.*").
-    # see https://github.com/kisielk/errcheck#the-deprecated-method for details
-    ignore: fmt:.*,io/ioutil:^Read.*
+    exclude-functions:
+      - io/ioutil.ReadFile
+      - io/ioutil.ReadDir
+      - io/ioutil.ReadAll
 
   govet:
     # report about shadowed variables
@@ -44,10 +46,6 @@ linters-settings:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)
     min-complexity: 15
 
-  maligned:
-    # print struct with more effective memory layout or not, false by default
-    suggest-new: true
-
   dupl:
     # tokens count to trigger issue, 150 by default
     threshold: 100
@@ -61,13 +59,6 @@ linters-settings:
   lll:
     # tab width in spaces. Default to 1.
     tab-width: 1
-
-  unused:
-    # treat code as a program (not a library) and report unused exported identifiers; default is false.
-    # XXX: if you enable this setting, unused will report a lot of false-positives in text editors:
-    # if it's called for subdir of a project it can't find funcs usages. All text editor integrations
-    # with golangci-lint call it on a directory with the changed file.
-    check-exported: false
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -104,17 +95,18 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
     - govet
     - gocyclo
     - gocritic
-    - interfacer
     - goconst
     - goimports
     - gofmt  # We enable this as well as goimports for its simplify mode.
+    - gosimple
     - prealloc
     - revive
+    - staticcheck
     - unconvert
+    - unused
     - misspell
     - nakedret
 
@@ -123,8 +115,9 @@ linters:
     - unused
   fast: false
 
-
 issues:
+  exclude-files:
+    - "zz_\\..+\\.go$"
   # Excluding configuration per-path and per-linter
   exclude-rules:
     # Exclude some linters from running on tests files.
@@ -148,31 +141,31 @@ issues:
     # rather than using a pointer.
     - text: "(hugeParam|rangeValCopy):"
       linters:
-        - gocritic
+      - gocritic
 
     # This "TestMain should call os.Exit to set exit code" warning is not clever
     # enough to notice that we call a helper method that calls os.Exit.
     - text: "SA3000:"
       linters:
-        - staticcheck
+      - staticcheck
 
     - text: "k8s.io/api/core/v1"
       linters:
-        - goimports
+      - goimports
 
     # This is a "potential hardcoded credentials" warning. It's triggered by
     # any variable with 'secret' in the same, and thus hits a lot of false
     # positives in Kubernetes land where a Secret is an object type.
     - text: "G101:"
       linters:
-        - gosec
-        - gas
+      - gosec
+      - gas
 
     # This is an 'errors unhandled' warning that duplicates errcheck.
     - text: "G104:"
       linters:
-        - gosec
-        - gas
+      - gosec
+      - gas
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
@@ -189,7 +182,7 @@ issues:
   new: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
-  max-per-linter: 0
+  max-issues-per-linter: 0
 
   # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
   max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ cobertura:
 
 # ====================================================================================
 # End to End Testing
+CROSSPLANE_VERSION = 1.17.2
 CROSSPLANE_NAMESPACE = crossplane-system
 -include build/makelib/local.xpkg.mk
 -include build/makelib/controlplane.mk
@@ -94,7 +95,7 @@ CROSSPLANE_NAMESPACE = crossplane-system
 UPTEST_EXAMPLE_LIST ?= "examples/sample/release.yaml"
 uptest: $(UPTEST) $(KUBECTL) $(KUTTL)
 	@$(INFO) running automated tests
-	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) $(UPTEST) e2e "$(UPTEST_EXAMPLE_LIST)" --setup-script=cluster/test/setup.sh || $(FAIL)
+	@KUBECTL=$(KUBECTL) KUTTL=$(KUTTL) CROSSPLANE_NAMESPACE=$(CROSSPLANE_NAMESPACE) $(UPTEST) e2e "$(UPTEST_EXAMPLE_LIST)" --setup-script=cluster/test/setup.sh || $(FAIL)
 	@$(OK) running automated tests
 
 local-dev: controlplane.up

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
 GO_LDFLAGS += -X $(GO_PROJECT)/pkg/version.Version=$(VERSION)
 GO_SUBDIRS += cmd pkg apis
 GO111MODULE = on
-GOLANGCILINT_VERSION = 1.55.2
+GOLANGCILINT_VERSION = 1.61.0
 
 -include build/makelib/golang.mk
 


### PR DESCRIPTION
### Description of your changes

Switch build submodule URL to `crossplane/build` and to the commit [d3155548bfab68fc8bea64c5526642b7b565ae33](https://github.com/crossplane/build/commit/d3155548bfab68fc8bea64c5526642b7b565ae33) which includes an update of `golangci-lint` to `1.61.0` to fix problems linting on macOS (arm64). See https://github.com/crossplane/build/pull/23

Also includes the following deprecation fixes:

- Update `.golangci.yml` config for several deprecated config settings
- Removed archived/deprecated linter `interfacer`
- Replaced `megacheck` with `gosimple`, `staticcheck`, and `unused`

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR if necessary.

### How has this code been tested

CI & `make lint` in local machine

[contribution process]: https://git.io/fj2m9
