### PR TITLE
202: Add Support for PlainHTTP for flexibility in chart downloads

### DIFF
--- a/apis/release/v1beta1/types.go
+++ b/apis/release/v1beta1/types.go
@@ -93,6 +93,8 @@ type ReleaseParameters struct {
 	SkipCRDs bool `json:"skipCRDs,omitempty"`
 	// InsecureSkipTLSVerify skips tls certificate checks for the chart download
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
+	// PlainHTTP uses insecure HTTP connections for the chart download
+	PlainHTTP bool `json:"plainHTTP,omitempty"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -701,6 +701,10 @@ spec:
                           type: object
                       type: object
                     type: array
+                  plainHTTP:
+                    description: PlainHTTP uses insecure HTTP connections for the
+                      chart download
+                    type: boolean
                   set:
                     items:
                       description: SetVal represents a "set" value override in a Release

--- a/pkg/clients/helm/args.go
+++ b/pkg/clients/helm/args.go
@@ -14,4 +14,6 @@ type Args struct {
 	SkipCRDs bool
 	// InsecureSkipTLSVerify skips tls certificate checks for the chart download
 	InsecureSkipTLSVerify bool
+	// PlainHTTP uses HTTP connections for the chart download
+	PlainHTTP bool
 }

--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -115,6 +115,7 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	pc.DestDir = chartCache
 	pc.Settings = &cli.EnvSettings{}
 	pc.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
+	pc.PlainHTTP = args.PlainHTTP
 
 	gc := action.NewGet(actionConfig)
 
@@ -124,12 +125,14 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	ic.Timeout = args.Timeout
 	ic.SkipCRDs = args.SkipCRDs
 	ic.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
+	ic.PlainHTTP = args.PlainHTTP
 
 	uc := action.NewUpgrade(actionConfig)
 	uc.Wait = args.Wait
 	uc.Timeout = args.Timeout
 	uc.SkipCRDs = args.SkipCRDs
 	uc.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
+	uc.PlainHTTP = args.PlainHTTP
 
 	uic := action.NewUninstall(actionConfig)
 	uic.Wait = args.Wait

--- a/pkg/controller/release/release.go
+++ b/pkg/controller/release/release.go
@@ -139,6 +139,7 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		config.Timeout = waitTimeout(cr)
 		config.SkipCRDs = cr.Spec.ForProvider.SkipCRDs
 		config.InsecureSkipTLSVerify = cr.Spec.ForProvider.InsecureSkipTLSVerify
+		config.PlainHTTP = cr.Spec.ForProvider.PlainHTTP
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #202":

-->

Fixes #202 
- Added PlainHTTP, which enables insecure HTTP connections for chart downloads
    -  useful in specific scenarios where secure connections are unavailable.
- Extended support for PlainHTTP across all relevant operations:
    - Install (InstallAction)
    - Upgrade (UpgradeAction)
    - Pull (PullAction)
- Updated CRD schema (`helm.crossplane.io_releases.yaml`) to include the new PlainHTTP field in the spec.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] ~~Run `make reviewable` to ensure this PR is ready for review.~~ There is no `reviewable` step in the Makefile


### How has this code been tested
- manually deployed the`package/crds/*` 
- deployed the  `examples/sample/release.yaml` by adding an extra line after L17 `plainHTTP: true`, without any errors. Before my changes, this line would have caused an error
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
