### PR TITLE
fix: remove omitempty in invalid json tag combination

### DIFF
--- a/apis/release/v1alpha1/types.go
+++ b/apis/release/v1alpha1/types.go
@@ -40,7 +40,7 @@ type NamespacedName struct {
 
 // DataKeySelector defines required spec to access a key of a configmap or secret
 type DataKeySelector struct {
-	NamespacedName `json:",inline,omitempty"`
+	NamespacedName `json:",inline"`
 	Key            string `json:"key,omitempty"`
 	Optional       bool   `json:"optional,omitempty"`
 }

--- a/apis/release/v1beta1/types.go
+++ b/apis/release/v1beta1/types.go
@@ -47,7 +47,7 @@ type NamespacedName struct {
 
 // DataKeySelector defines required spec to access a key of a configmap or secret
 type DataKeySelector struct {
-	NamespacedName `json:",inline,omitempty"`
+	NamespacedName `json:",inline"`
 	Key            string `json:"key,omitempty"`
 	Optional       bool   `json:"optional,omitempty"`
 }


### PR DESCRIPTION
### Description of your changes

As mentioned in https://github.com/crossplane/function-sdk-go/issues/161 and further https://github.com/go-json-experiment/json/pull/39 "inline,omitempty" is an invalid combination of json tags. This leads to issues in marshaling DataKeySelector. 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

We have tested the modified types.go locally in our e2e tests. This shouldn't be a breaking change as it wasn't working in crossplane functions until now. Also CRDs have not changed.

[contribution process]: https://git.io/fj2m9

Would appreciate a 0.20 or even 0.19 backport
