### PR TITLE
Update go version to 1.23.6 [SECURITY]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/crossplane-contrib/provider-helm
 
-go 1.23
+go 1.23.6
 
 require (
 	github.com/crossplane-contrib/provider-kubernetes v0.14.0-rc0.0.20240528114550-5b2412e9cab8


### PR DESCRIPTION
### Description of your changes

The `go1.23`means automatically consuming the latest patch version. However, in the pipelines we need specific patch version. So, we updated it here.

| Name | Change | Type | Vulnerability | Severity |
|---|---|---|---|---|
| stdlib | `go1.23` -> `go1.23.6` | go-module | CVE-2024-45341 | Medium |
| stdlib | `go1.23` -> `go1.23.6` | go-module | CVE-2024-45336 | Medium |
| stdlib | `go1.23` -> `go1.23.6` | go-module | CVE-2025-22866 | - |

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

[contribution process]: https://git.io/fj2m9
