### PR TITLE
Add support for revisions history limit

### DIFF
--- a/apis/release/v1beta1/types.go
+++ b/apis/release/v1beta1/types.go
@@ -93,6 +93,9 @@ type ReleaseParameters struct {
 	SkipCRDs bool `json:"skipCRDs,omitempty"`
 	// InsecureSkipTLSVerify skips tls certificate checks for the chart download
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
+	// MaxHistory limits the maximum number of revisions saved per release. Use 0 for no limit.
+	// +kubebuilder:default:=20
+	MaxHistory int `json:"MaxHistory"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -620,6 +620,11 @@ spec:
               forProvider:
                 description: ReleaseParameters are the configurable fields of a Release.
                 properties:
+                  MaxHistory:
+                    default: 20
+                    description: MaxHistory limits the maximum number of revisions
+                      saved per release. Use 0 for no limit.
+                    type: integer
                   chart:
                     description: A ChartSpec defines the chart spec for a Release
                     properties:
@@ -806,6 +811,7 @@ spec:
                       ready. Only applies if wait is also set. Defaults to 5m.
                     type: string
                 required:
+                - MaxHistory
                 - chart
                 - namespace
                 type: object

--- a/pkg/clients/helm/args.go
+++ b/pkg/clients/helm/args.go
@@ -14,4 +14,6 @@ type Args struct {
 	SkipCRDs bool
 	// InsecureSkipTLSVerify skips tls certificate checks for the chart download
 	InsecureSkipTLSVerify bool
+	// MaxHistory limits the maximum number of revisions saved per release.
+	MaxHistory int
 }

--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -39,9 +39,8 @@ import (
 )
 
 const (
-	helmDriverSecret  = "secret"
-	chartCache        = "/tmp/charts"
-	releaseMaxHistory = 20
+	helmDriverSecret = "secret"
+	chartCache       = "/tmp/charts"
 )
 
 const (
@@ -130,6 +129,7 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	uc.Timeout = args.Timeout
 	uc.SkipCRDs = args.SkipCRDs
 	uc.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
+	uc.MaxHistory = args.MaxHistory
 
 	uic := action.NewUninstall(actionConfig)
 	uic.Wait = args.Wait
@@ -322,7 +322,6 @@ func (hc *client) Install(release string, chart *chart.Chart, vals map[string]in
 func (hc *client) Upgrade(release string, chart *chart.Chart, vals map[string]interface{}, patches []ktype.Patch) (*release.Release, error) {
 	// Reset values so that source of truth for desired state is always the CR itself
 	hc.upgradeClient.ResetValues = true
-	hc.upgradeClient.MaxHistory = releaseMaxHistory
 
 	if len(patches) > 0 {
 		hc.upgradeClient.PostRenderer = &KustomizationRender{

--- a/pkg/controller/release/release.go
+++ b/pkg/controller/release/release.go
@@ -139,6 +139,7 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		config.Timeout = waitTimeout(cr)
 		config.SkipCRDs = cr.Spec.ForProvider.SkipCRDs
 		config.InsecureSkipTLSVerify = cr.Spec.ForProvider.InsecureSkipTLSVerify
+		config.MaxHistory = cr.Spec.ForProvider.MaxHistory
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I added support for the max history limit configuration. Otherwise, we have lots of big secrets on the cluster, because of hardcoded 20 revisions history. For backward compatibility, I left the 20 history limit by default (Helm cli has 10 as the default).

https://helm.sh/docs/helm/helm_upgrade/#options

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Tested on live cluster and upgraded release multiple times.

[contribution process]: https://git.io/fj2m9
