### PR TITLE
Configurable ports

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -30,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	changelogsv1alpha1 "github.com/crossplane/crossplane-runtime/v2/apis/changelogs/proto/v1alpha1"
 	"github.com/crossplane/crossplane-runtime/v2/pkg/controller"
@@ -78,6 +80,8 @@ func main() {
 		pollInterval            = app.Flag("poll", "How often individual resources will be checked for drift from the desired state").Default("10m").Duration()
 		pollStateMetricInterval = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("100").Int()
+		webhookPort             = app.Flag("webhook-port", "Port for the webhook server.").Default("9443").Int()
+		metricsBindAddress      = app.Flag("metrics-bind-address", "Address for the metrics server.").Default(":8080").String()
 
 		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 		enableChangeLogs         = app.Flag("enable-changelogs", "Enable support for capturing change logs during reconciliation.").Default("false").Envar("ENABLE_CHANGE_LOGS").Bool()
@@ -102,6 +106,12 @@ func main() {
 	mgr, err := ctrl.NewManager(ratelimiter.LimitRESTConfig(cfg, *maxReconcileRate), ctrl.Options{
 		Cache: cache.Options{
 			SyncPeriod: syncInterval,
+		},
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Port: *webhookPort,
+		}),
+		Metrics: metricsserver.Options{
+			BindAddress: *metricsBindAddress,
 		},
 
 		// controller-runtime uses both ConfigMaps and Leases for leader

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -81,9 +81,9 @@ func main() {
 		pollInterval            = app.Flag("poll", "How often individual resources will be checked for drift from the desired state").Default("10m").Duration()
 		pollStateMetricInterval = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("100").Int()
-		webhookPort             = app.Flag("webhook-port", "Port for the webhook server.").Default("9443").Envar("WEBHOOK_PORT").Int()
-		metricsPort             = app.Flag("metrics-port", "Port for the metrics server.").Default("8080").Envar("METRICS_PORT").Int()
-		healthProbePort         = app.Flag("health-probe-port", "Port for the health probe server.").Default("8081").Envar("HEALTH_PROBE_PORT").Int()
+		webhookPort             = app.Flag("webhook-port", "The port the webhook server listens on.").Default("9443").Envar("WEBHOOK_PORT").Int()
+		metricsPort             = app.Flag("metrics-port", "The port the metrics server listens on.").Default("8080").Envar("METRICS_PORT").Int()
+		healthProbePort         = app.Flag("health-probe-port", "The port the health probe endpoint listens on.").Default("8081").Envar("HEALTH_PROBE_PORT").Int()
 
 		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 		enableChangeLogs         = app.Flag("enable-changelogs", "Enable support for capturing change logs during reconciliation.").Default("false").Envar("ENABLE_CHANGE_LOGS").Bool()
@@ -243,28 +243,13 @@ func canWatchCRD(ctx context.Context, mgr manager.Manager) (bool, error) {
 	return true, nil
 }
 
-// setupHealthProbes configures liveness and readiness probes for the manager
+// setupHealthProbes sets up the health and readiness probes.
 func setupHealthProbes(mgr ctrl.Manager) error {
-	log := logging.NewLogrLogger(zap.New().WithName("health-probes"))
-
-	// Add readiness probe
-	if err := mgr.AddReadyzCheck("ready", func(_ *http.Request) error {
-		// Add any specific readiness checks here
-		return nil
-	}); err != nil {
-		log.Debug("Unable to set up readiness check", "error", err)
-		return err
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return errors.Wrap(err, "cannot add readiness probe")
 	}
-
-	// Add liveness probe
-	if err := mgr.AddHealthzCheck("healthz", func(_ *http.Request) error {
-		// Add any specific liveness checks here
-		return nil
-	}); err != nil {
-		log.Debug("Unable to set up health check", "error", err)
-		return err
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return errors.Wrap(err, "cannot add liveness probe")
 	}
-
-	log.Debug("Health probes configured successfully")
 	return nil
 }

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"path/filepath"
 	"time"
@@ -80,8 +81,9 @@ func main() {
 		pollInterval            = app.Flag("poll", "How often individual resources will be checked for drift from the desired state").Default("10m").Duration()
 		pollStateMetricInterval = app.Flag("poll-state-metric", "State metric recording interval").Default("5s").Duration()
 		maxReconcileRate        = app.Flag("max-reconcile-rate", "The global maximum rate per second at which resources may checked for drift from the desired state.").Default("100").Int()
-		webhookPort             = app.Flag("webhook-port", "Port for the webhook server.").Default("9443").Int()
-		metricsBindAddress      = app.Flag("metrics-bind-address", "Address for the metrics server.").Default(":8080").String()
+		webhookPort             = app.Flag("webhook-port", "Port for the webhook server.").Default("9443").Envar("WEBHOOK_PORT").Int()
+		metricsPort             = app.Flag("metrics-port", "Port for the metrics server.").Default("8080").Envar("METRICS_PORT").Int()
+		healthProbePort         = app.Flag("health-probe-port", "Port for the health probe server.").Default("8081").Envar("HEALTH_PROBE_PORT").Int()
 
 		enableManagementPolicies = app.Flag("enable-management-policies", "Enable support for Management Policies.").Default("true").Envar("ENABLE_MANAGEMENT_POLICIES").Bool()
 		enableChangeLogs         = app.Flag("enable-changelogs", "Enable support for capturing change logs during reconciliation.").Default("false").Envar("ENABLE_CHANGE_LOGS").Bool()
@@ -111,8 +113,9 @@ func main() {
 			Port: *webhookPort,
 		}),
 		Metrics: metricsserver.Options{
-			BindAddress: *metricsBindAddress,
+			BindAddress: fmt.Sprintf(":%d", *metricsPort),
 		},
+		HealthProbeBindAddress: fmt.Sprintf(":%d", *healthProbePort),
 
 		// controller-runtime uses both ConfigMaps and Leases for leader
 		// election by default. Leases expire after 15 seconds, with a
@@ -201,6 +204,10 @@ func main() {
 		kingpin.FatalIfError(clustercontroller.Setup(mgr, clusterOpts, *timeout), "Cannot setup cluster-scoped AzureAD controllers")
 		kingpin.FatalIfError(namespacedcontroller.Setup(mgr, namespacedOpts, *timeout), "Cannot setup namespaced AzureAD controllers")
 	}
+
+	// Setup health probes
+	kingpin.FatalIfError(setupHealthProbes(mgr), "Cannot setup health probes")
+
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }
 
@@ -234,4 +241,30 @@ func canWatchCRD(ctx context.Context, mgr manager.Manager) (bool, error) {
 		}
 	}
 	return true, nil
+}
+
+// setupHealthProbes configures liveness and readiness probes for the manager
+func setupHealthProbes(mgr ctrl.Manager) error {
+	log := logging.NewLogrLogger(zap.New().WithName("health-probes"))
+
+	// Add readiness probe
+	if err := mgr.AddReadyzCheck("ready", func(_ *http.Request) error {
+		// Add any specific readiness checks here
+		return nil
+	}); err != nil {
+		log.Debug("Unable to set up readiness check", "error", err)
+		return err
+	}
+
+	// Add liveness probe
+	if err := mgr.AddHealthzCheck("healthz", func(_ *http.Request) error {
+		// Add any specific liveness checks here
+		return nil
+	}); err != nil {
+		log.Debug("Unable to set up health check", "error", err)
+		return err
+	}
+
+	log.Debug("Health probes configured successfully")
+	return nil
 }


### PR DESCRIPTION
### Description of your changes

Fixes #274: This change adds support for configuring the ports for the webhook (see https://github.com/crossplane/crossplane/issues/6291) 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

I ran the provider and tested that the health probe is present and that the port is configurable. Also tested that the metrics port is configurable using `curl localhost:8080/metrics` 
The webhook isn't even enabled so testing is not possible. I left the code in-place for configuring the port in the future.  
