### PR TITLE
Add TakeOwnership Option for Helm Release Management

### DIFF
--- a/apis/cluster/release/v1beta1/types.go
+++ b/apis/cluster/release/v1beta1/types.go
@@ -106,6 +106,9 @@ type ReleaseParameters struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 	// PlainHTTP uses insecure HTTP connections for the chart download
 	PlainHTTP bool `json:"plainHTTP,omitempty"`
+	// TakeOwnership ignore the check for helm annotations and take ownership
+	// of the existing resources.
+	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/apis/cluster/release/v1beta1/types.go
+++ b/apis/cluster/release/v1beta1/types.go
@@ -106,8 +106,11 @@ type ReleaseParameters struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 	// PlainHTTP uses insecure HTTP connections for the chart download
 	PlainHTTP bool `json:"plainHTTP,omitempty"`
-	// TakeOwnership ignore the check for helm annotations and take ownership
-	// of the existing resources.
+	// TakeOwnership ignores Helm ownership validation and adopts pre-existing releases.
+	// This is a ONE-TIME operation: after the first successful deployment, the flag is recorded
+	// in status.atProvider.ownershipTaken and subsequent reconciles use normal Helm validation.
+	// This prevents silent adoption of unrelated resources during chart upgrades.
+	// Use this field to migrate manually-deployed Helm releases into Crossplane management.
 	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
@@ -120,6 +123,10 @@ type ReleaseObservation struct {
 	Digest string `json:"digest,omitempty"`
 	// Version is the actual deployed chart version.
 	Version string `json:"version,omitempty"`
+	// OwnershipTaken indicates that spec.forProvider.takeOwnership was used for initial adoption.
+	// Once set to true, subsequent reconciles use normal Helm validation instead of takeOwnership,
+	// preventing silent adoption of unrelated resources during upgrades.
+	OwnershipTaken bool `json:"ownershipTaken,omitempty"`
 }
 
 // A ReleaseSpec defines the desired state of a Release.

--- a/apis/namespaced/release/v1beta1/types.go
+++ b/apis/namespaced/release/v1beta1/types.go
@@ -102,6 +102,9 @@ type ReleaseParameters struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 	// PlainHTTP uses insecure HTTP connections for the chart download
 	PlainHTTP bool `json:"plainHTTP,omitempty"`
+	// TakeOwnership ignore the check for helm annotations and take ownership
+	// of the existing resources.
+	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/apis/namespaced/release/v1beta1/types.go
+++ b/apis/namespaced/release/v1beta1/types.go
@@ -102,8 +102,11 @@ type ReleaseParameters struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 	// PlainHTTP uses insecure HTTP connections for the chart download
 	PlainHTTP bool `json:"plainHTTP,omitempty"`
-	// TakeOwnership ignore the check for helm annotations and take ownership
-	// of the existing resources.
+	// TakeOwnership ignores Helm ownership validation and adopts pre-existing releases.
+	// This is a ONE-TIME operation: after the first successful deployment, the flag is recorded
+	// in status.atProvider.ownershipTaken and subsequent reconciles use normal Helm validation.
+	// This prevents silent adoption of unrelated resources during chart upgrades.
+	// Use this field to migrate manually-deployed Helm releases into Crossplane management.
 	TakeOwnership bool `json:"takeOwnership,omitempty"`
 }
 
@@ -116,6 +119,10 @@ type ReleaseObservation struct {
 	Digest string `json:"digest,omitempty"`
 	// Version is the actual deployed chart version.
 	Version string `json:"version,omitempty"`
+	// OwnershipTaken indicates that spec.forProvider.takeOwnership was used for initial adoption.
+	// Once set to true, subsequent reconciles use normal Helm validation instead of takeOwnership,
+	// preventing silent adoption of unrelated resources during upgrades.
+	OwnershipTaken bool `json:"ownershipTaken,omitempty"`
 }
 
 // A ReleaseSpec defines the desired state of a Release.

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -699,8 +699,11 @@ spec:
                     type: boolean
                   takeOwnership:
                     description: |-
-                      TakeOwnership ignore the check for helm annotations and take ownership
-                      of the existing resources.
+                      TakeOwnership ignores Helm ownership validation and adopts pre-existing releases.
+                      This is a ONE-TIME operation: after the first successful deployment, the flag is recorded
+                      in status.atProvider.ownershipTaken and subsequent reconciles use normal Helm validation.
+                      This prevents silent adoption of unrelated resources during chart upgrades.
+                      Use this field to migrate manually-deployed Helm releases into Crossplane management.
                     type: boolean
                   values:
                     type: object
@@ -856,6 +859,12 @@ spec:
                     description: Digest is the last successfully deployed chart digest
                       (for OCI charts only).
                     type: string
+                  ownershipTaken:
+                    description: |-
+                      OwnershipTaken indicates that spec.forProvider.takeOwnership was used for initial adoption.
+                      Once set to true, subsequent reconciles use normal Helm validation instead of takeOwnership,
+                      preventing silent adoption of unrelated resources during upgrades.
+                    type: boolean
                   releaseDescription:
                     type: string
                   revision:

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -697,6 +697,11 @@ spec:
                     description: SkipCreateNamespace won't create the namespace for
                       the release. This requires the namespace to already exist.
                     type: boolean
+                  takeOwnership:
+                    description: |-
+                      TakeOwnership ignore the check for helm annotations and take ownership
+                      of the existing resources.
+                    type: boolean
                   values:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/package/crds/helm.m.crossplane.io_releases.yaml
+++ b/package/crds/helm.m.crossplane.io_releases.yaml
@@ -260,6 +260,11 @@ spec:
                     description: SkipCreateNamespace won't create the namespace for
                       the release. This requires the namespace to already exist.
                     type: boolean
+                  takeOwnership:
+                    description: |-
+                      TakeOwnership ignore the check for helm annotations and take ownership
+                      of the existing resources.
+                    type: boolean
                   values:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true

--- a/package/crds/helm.m.crossplane.io_releases.yaml
+++ b/package/crds/helm.m.crossplane.io_releases.yaml
@@ -262,8 +262,11 @@ spec:
                     type: boolean
                   takeOwnership:
                     description: |-
-                      TakeOwnership ignore the check for helm annotations and take ownership
-                      of the existing resources.
+                      TakeOwnership ignores Helm ownership validation and adopts pre-existing releases.
+                      This is a ONE-TIME operation: after the first successful deployment, the flag is recorded
+                      in status.atProvider.ownershipTaken and subsequent reconciles use normal Helm validation.
+                      This prevents silent adoption of unrelated resources during chart upgrades.
+                      Use this field to migrate manually-deployed Helm releases into Crossplane management.
                     type: boolean
                   values:
                     type: object
@@ -384,6 +387,12 @@ spec:
                     description: Digest is the last successfully deployed chart digest
                       (for OCI charts only).
                     type: string
+                  ownershipTaken:
+                    description: |-
+                      OwnershipTaken indicates that spec.forProvider.takeOwnership was used for initial adoption.
+                      Once set to true, subsequent reconciles use normal Helm validation instead of takeOwnership,
+                      preventing silent adoption of unrelated resources during upgrades.
+                    type: boolean
                   releaseDescription:
                     type: string
                   revision:

--- a/pkg/clients/helm/args.go
+++ b/pkg/clients/helm/args.go
@@ -16,4 +16,7 @@ type Args struct {
 	InsecureSkipTLSVerify bool
 	// PlainHTTP uses HTTP connections for the chart download
 	PlainHTTP bool
+	// TakeOwnership ignore the check for helm annotations and take ownership
+	// of the existing resources.
+	TakeOwnership bool
 }

--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -137,6 +137,7 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	ic.SkipCRDs = args.SkipCRDs
 	ic.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
 	ic.PlainHTTP = args.PlainHTTP
+	ic.TakeOwnership = args.TakeOwnership
 
 	uc := action.NewUpgrade(actionConfig)
 	uc.Wait = args.Wait
@@ -144,6 +145,7 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	uc.SkipCRDs = args.SkipCRDs
 	uc.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
 	uc.PlainHTTP = args.PlainHTTP
+	uc.TakeOwnership = args.TakeOwnership
 
 	uic := action.NewUninstall(actionConfig)
 	uic.Wait = args.Wait

--- a/pkg/controller/cluster/release/release.go
+++ b/pkg/controller/cluster/release/release.go
@@ -154,6 +154,7 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		config.SkipCRDs = cr.Spec.ForProvider.SkipCRDs
 		config.InsecureSkipTLSVerify = cr.Spec.ForProvider.InsecureSkipTLSVerify
 		config.PlainHTTP = cr.Spec.ForProvider.PlainHTTP
+		config.TakeOwnership = cr.Spec.ForProvider.TakeOwnership
 	}
 }
 

--- a/pkg/controller/cluster/release/release.go
+++ b/pkg/controller/cluster/release/release.go
@@ -154,7 +154,9 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		config.SkipCRDs = cr.Spec.ForProvider.SkipCRDs
 		config.InsecureSkipTLSVerify = cr.Spec.ForProvider.InsecureSkipTLSVerify
 		config.PlainHTTP = cr.Spec.ForProvider.PlainHTTP
-		config.TakeOwnership = cr.Spec.ForProvider.TakeOwnership
+		// Only use TakeOwnership if requested AND not already used
+		// This prevents silent adoption of resources during upgrades after initial adoption
+		config.TakeOwnership = cr.Spec.ForProvider.TakeOwnership && !cr.Status.AtProvider.OwnershipTaken
 	}
 }
 
@@ -271,7 +273,7 @@ func (e *helmExternal) Observe(ctx context.Context, mg resource.Managed) (manage
 
 type deployAction func(release string, chart *chart.Chart, vals map[string]interface{}, patches []ktype.Patch) (*release.Release, error)
 
-func (e *helmExternal) deploy(ctx context.Context, cr *v1beta1.Release, action deployAction) error {
+func (e *helmExternal) deploy(ctx context.Context, cr *v1beta1.Release, action deployAction) error { //nolint:gocyclo // easier to follow as a unit
 	cv, err := composeValuesFromSpec(ctx, e.localKube, cr.Spec.ForProvider.ValuesSpec)
 	if err != nil {
 		return errors.Wrap(err, errFailedToComposeValues)
@@ -338,6 +340,10 @@ func (e *helmExternal) deploy(ctx context.Context, cr *v1beta1.Release, action d
 	cr.Status.AtProvider = generateObservation(rel)
 	// Store the digest in status for drift detection
 	cr.Status.AtProvider.Digest = cr.Spec.ForProvider.Chart.Digest
+	// Mark ownership as taken if TakeOwnership was used
+	if cr.Spec.ForProvider.TakeOwnership {
+		cr.Status.AtProvider.OwnershipTaken = true
+	}
 
 	return nil
 }

--- a/pkg/controller/cluster/release/release_test.go
+++ b/pkg/controller/cluster/release/release_test.go
@@ -3,6 +3,7 @@ package release
 import (
 	"context"
 	"testing"
+	"time"
 
 	kubeclient "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/client"
 	kconfig "github.com/crossplane-contrib/provider-kubernetes/pkg/kube/config"
@@ -860,6 +861,68 @@ func Test_helmExternal_Delete(t *testing.T) {
 			_, gotErr := e.Delete(context.Background(), tc.args.mg)
 			if diff := cmp.Diff(tc.want.err, gotErr, test.EquateErrors()); diff != "" {
 				t.Fatalf("e.Delete(...): -want error, +got error: %s", diff)
+			}
+		})
+	}
+}
+
+func Test_withRelease(t *testing.T) {
+	type args struct {
+		cr *v1beta1.Release
+	}
+	type want struct {
+		args helmClient.Args
+	}
+	timeout := metav1.Duration{Duration: 10 * time.Minute}
+	cases := map[string]struct {
+		args
+		want
+	}{
+		"AllFieldsSet": {
+			args: args{
+				cr: helmRelease(func(r *v1beta1.Release) {
+					r.Spec.ForProvider.Namespace = "test-namespace"
+					r.Spec.ForProvider.Wait = true
+					r.Spec.ForProvider.WaitTimeout = &timeout
+					r.Spec.ForProvider.SkipCRDs = true
+					r.Spec.ForProvider.InsecureSkipTLSVerify = true
+					r.Spec.ForProvider.PlainHTTP = true
+					r.Spec.ForProvider.TakeOwnership = true
+				}),
+			},
+			want: want{
+				args: helmClient.Args{
+					Namespace:             "test-namespace",
+					Wait:                  true,
+					Timeout:               10 * time.Minute,
+					SkipCRDs:              true,
+					InsecureSkipTLSVerify: true,
+					PlainHTTP:             true,
+					TakeOwnership:         true,
+				},
+			},
+		},
+		"TakeOwnershipFalse": {
+			args: args{
+				cr: helmRelease(func(r *v1beta1.Release) {
+					r.Spec.ForProvider.TakeOwnership = false
+				}),
+			},
+			want: want{
+				args: helmClient.Args{
+					Timeout:       5 * time.Minute, // default timeout
+					TakeOwnership: false,
+				},
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			applier := withRelease(tc.args.cr)
+			got := &helmClient.Args{}
+			applier(got)
+			if diff := cmp.Diff(tc.want.args, *got); diff != "" {
+				t.Fatalf("withRelease(...): -want args, +got args: %s", diff)
 			}
 		})
 	}

--- a/pkg/controller/namespaced/release/release.go
+++ b/pkg/controller/namespaced/release/release.go
@@ -159,6 +159,9 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		config.SkipCRDs = cr.Spec.ForProvider.SkipCRDs
 		config.InsecureSkipTLSVerify = cr.Spec.ForProvider.InsecureSkipTLSVerify
 		config.PlainHTTP = cr.Spec.ForProvider.PlainHTTP
+		// Only use TakeOwnership if requested AND not already used
+		// This prevents silent adoption of resources during upgrades after initial adoption
+		config.TakeOwnership = cr.Spec.ForProvider.TakeOwnership && !cr.Status.AtProvider.OwnershipTaken
 	}
 }
 
@@ -275,7 +278,7 @@ func (e *helmExternal) Observe(ctx context.Context, mg resource.Managed) (manage
 
 type deployAction func(release string, chart *chart.Chart, vals map[string]interface{}, patches []ktype.Patch) (*release.Release, error)
 
-func (e *helmExternal) deploy(ctx context.Context, cr *v1beta1.Release, action deployAction) error {
+func (e *helmExternal) deploy(ctx context.Context, cr *v1beta1.Release, action deployAction) error { //nolint:gocyclo // easier to follow as a unit
 	cv, err := composeValuesFromSpec(ctx, e.localKube, cr.Spec.ForProvider.ValuesSpec, cr.Namespace)
 	if err != nil {
 		return errors.Wrap(err, errFailedToComposeValues)
@@ -346,6 +349,10 @@ func (e *helmExternal) deploy(ctx context.Context, cr *v1beta1.Release, action d
 	cr.Status.AtProvider = generateObservation(rel)
 	// Store the digest in status for drift detection
 	cr.Status.AtProvider.Digest = cr.Spec.ForProvider.Chart.Digest
+	// Mark ownership as taken if TakeOwnership was used
+	if cr.Spec.ForProvider.TakeOwnership {
+		cr.Status.AtProvider.OwnershipTaken = true
+	}
 
 	return nil
 }


### PR DESCRIPTION
### Description of your changes

Add TakeOwnership Option for Helm Release Management

Upstream Helm PR <https://github.com/helm/helm/pull/12876>

This PR includes the SHA support code from #324. It will remain in draft until that is merged. 

## Summary

Add a `takeOwnership` boolean field to Release resources that allows provider-helm to ignore Helm annotation checks and take ownership of existing Helm releases. This enables Crossplane to manage Helm releases that were initially deployed outside of Crossplane.

## Problem

When adopting existing Helm releases into Crossplane management, Helm's default behavior prevents taking over releases that lack the proper Crossplane annotations. This creates a barrier for teams migrating existing infrastructure to Crossplane-managed workflows.

## Solution

Introduce a `takeOwnership` field that bypasses Helm's annotation checks, allowing Crossplane to adopt and manage pre-existing Helm releases.

## API Changes

Added `TakeOwnership` boolean field to both cluster-scoped and namespaced Release APIs:

```yaml
apiVersion: helm.crossplane.io/v1beta1
kind: Release
metadata:
  name: my-release
spec:
  forProvider:
    chart:
      name: mychart
      repository: https://charts.example.com
      version: 1.2.3
    namespace: default
    takeOwnership: true  # New field
  providerConfigRef:
    name: helm-provider
```

## Implementation Details

- Added `TakeOwnership` field to `ReleaseParameters` in cluster and namespaced APIs
- Extended `Args` struct to pass the configuration through the Helm client
- Configured install and upgrade clients to respect the `TakeOwnership` setting
- Wired field through controller to apply to Helm operations

## Test Coverage

Added unit tests:
- Test case with `takeOwnership: true`
- Test case with `takeOwnership: false`
- Validation that the field properly flows through the configuration chain

## Use Cases

1. **Migration**: Adopt existing Helm releases deployed manually or via other tools
2. **Disaster Recovery**: Restore Crossplane management after manual intervention
3. **Multi-Tool Workflows**: Manage releases that may be temporarily operated by other automation

## Notes

- This field is optional and defaults to `false` to maintain safe, non-invasive behavior
- When enabled, bypasses Helm's annotation-based ownership checks
- Works with both Install and Upgrade operations
- Generated CRDs automatically include the new field



I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
