### PR TITLE
Support repository charts with unconventional .tgz filename

### DIFF
--- a/examples/cluster/sample/release-nonconventional-tgz.yaml
+++ b/examples/cluster/sample/release-nonconventional-tgz.yaml
@@ -1,0 +1,19 @@
+# Regression coverage for classic-repository charts whose published tarball
+# basename differs from <name>-<version>.tgz. node-feature-discovery 0.18.3 is
+# advertised in the repository index but hosted as the release asset
+# node-feature-discovery-chart-0.18.3.tgz (note the -chart- infix), so the
+# provider must load the chart from the path Helm actually saved it under
+# rather than reconstructing <name>-<version>.tgz.
+apiVersion: helm.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: node-feature-discovery
+spec:
+  forProvider:
+    namespace: nfd
+    chart:
+      name: node-feature-discovery
+      repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+      version: "0.18.3"
+  providerConfigRef:
+    name: helm-provider

--- a/examples/namespaced/sample/release-nonconventional-tgz.yaml
+++ b/examples/namespaced/sample/release-nonconventional-tgz.yaml
@@ -1,0 +1,21 @@
+# Regression coverage for classic-repository charts whose published tarball
+# basename differs from <name>-<version>.tgz. node-feature-discovery 0.18.3 is
+# advertised in the repository index but hosted as the release asset
+# node-feature-discovery-chart-0.18.3.tgz (note the -chart- infix), so the
+# provider must load the chart from the path Helm actually saved it under
+# rather than reconstructing <name>-<version>.tgz.
+apiVersion: helm.m.crossplane.io/v1beta1
+kind: Release
+metadata:
+  name: node-feature-discovery
+  namespace: crossplane-system
+spec:
+  forProvider:
+    namespace: nfd
+    chart:
+      name: node-feature-discovery
+      repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
+      version: "0.18.3"
+  providerConfigRef:
+    name: helm-provider-cluster
+    kind: ClusterProviderConfig

--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -173,8 +173,12 @@ func getChartFileName(dir string) (string, error) {
 	return files[0].Name(), nil
 }
 
-// Pulls latest chart version. Returns absolute chartFilePath or error.
-func (hc *client) pullLatestChartVersion(chartUrl, chartName, chartVersion, chartRepo string, creds *RepoCreds) (string, error) {
+// pullChartToCache pulls the chart into the cache directory and returns the
+// absolute path it was actually saved under. The chart is first pulled into a
+// temporary directory so its real tarball name can be discovered: Helm derives
+// the local filename from the artifact URL resolved via the repository
+// index.yaml urls field, which is not necessarily <name>-<version>.tgz.
+func (hc *client) pullChartToCache(chartUrl, chartName, chartVersion, chartRepo string, creds *RepoCreds) (string, error) {
 	tmpDir, err := os.MkdirTemp(chartCache, "")
 	if err != nil {
 		return "", err
@@ -280,7 +284,7 @@ func (hc *client) PullAndLoadChart(mg resource.Managed, creds *RepoCreds) (*char
 
 	switch {
 	case chartUrl == "" && (chartVersion == "" || chartVersion == devel):
-		chartFilePath, err = hc.pullLatestChartVersion(chartUrl, chartName, chartVersion, chartRepo, creds)
+		chartFilePath, err = hc.pullChartToCache(chartUrl, chartName, chartVersion, chartRepo, creds)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +295,7 @@ func (hc *client) PullAndLoadChart(mg resource.Managed, creds *RepoCreds) (*char
 		}
 
 		if v == "" {
-			chartFilePath, err = hc.pullLatestChartVersion(chartUrl, chartName, chartVersion, chartRepo, creds)
+			chartFilePath, err = hc.pullChartToCache(chartUrl, chartName, chartVersion, chartRepo, creds)
 			if err != nil {
 				return nil, err
 			}
@@ -305,7 +309,14 @@ func (hc *client) PullAndLoadChart(mg resource.Managed, creds *RepoCreds) (*char
 		}
 		chartFilePath = filepath.Join(chartCache, path.Base(u.Path))
 	default:
-		chartFilePath = resolveChartFilePath(chartName, chartVersion)
+		// Classic repository mode. Reuse a conventionally-named cached chart
+		// when present; otherwise pull and load it from the path Helm actually
+		// saved it under, since a repository may advertise a tarball name that
+		// differs from <name>-<version>.tgz.
+		chartFilePath, err = hc.cachedOrPulledChartPath(chartName, chartVersion, chartRepo, creds)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if _, err := os.Stat(chartFilePath); os.IsNotExist(err) {
@@ -383,6 +394,20 @@ func resolveOCIChartVersion(chartURL string) (*url.URL, string, error) {
 func resolveChartFilePath(name string, version string) string {
 	filename := fmt.Sprintf("%s-%s.tgz", name, version)
 	return filepath.Join(chartCache, filename)
+}
+
+// cachedOrPulledChartPath returns the path to a conventionally-named cached
+// chart if it already exists, otherwise pulls the chart and returns the path it
+// was actually saved under. The saved name can differ from <name>-<version>.tgz
+// when a repository advertises a non-conventional tarball name in its index.
+func (hc *client) cachedOrPulledChartPath(chartName, chartVersion, chartRepo string, creds *RepoCreds) (string, error) {
+	chartFilePath := resolveChartFilePath(chartName, chartVersion)
+	if _, err := os.Stat(chartFilePath); err == nil {
+		return chartFilePath, nil
+	} else if !os.IsNotExist(err) {
+		return "", errors.Wrap(err, errFailedToCheckIfLocalChartExists)
+	}
+	return hc.pullChartToCache("", chartName, chartVersion, chartRepo, creds)
 }
 
 func resolveOCIChartRef(repository string, name string) string {


### PR DESCRIPTION
### Description of your changes
Fixes #336 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested
Added new E2E test target and tested E2E "classic release" and the new release with unconventional tgz path
`UPTEST_EXAMPLE_LIST="examples/namespaced/sample/release-nonconventional-tgz.yaml" make e2e`
(`/test-examples="examples/namespaced/sample/release-nonconventional-tgz.yaml"` for the pipeline :))

Before (running provider-helm from main):
```yaml
apiVersion: helm.m.crossplane.io/v1beta1
kind: Release
metadata:
  annotations:
    crossplane.io/external-create-failed: "2026-06-13T14:23:04Z"
    crossplane.io/external-create-pending: "2026-06-13T14:23:04Z"
    crossplane.io/external-name: node-feature-discovery
    upjet.upbound.io/test: "true"
  creationTimestamp: "2026-06-13T14:22:58Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 2
  name: node-feature-discovery
  namespace: crossplane-system
  resourceVersion: "1049"
  uid: 5aa194de-33ad-4a12-b74c-59d04c3e8fae
spec:
  forProvider:
    chart:
      name: node-feature-discovery
      pullSecretRef:
        name: ""
      repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
      version: 0.18.3
    namespace: nfd
  managementPolicies:
  - '*'
  providerConfigRef:
    kind: ClusterProviderConfig
    name: helm-provider-cluster
status:
  atProvider: {}
  conditions:
  - lastTransitionTime: "2026-06-13T14:22:58Z"
    observedGeneration: 2
    reason: Creating
    status: "False"
    type: Ready
  - lastTransitionTime: "2026-06-13T14:22:58Z"
    message: 'create failed: failed to install release: failed to load chart: stat
      /tmp/charts/node-feature-discovery-0.18.3.tgz: no such file or directory'
    observedGeneration: 2
    reason: ReconcileError
    status: "False"
    type: Synced
```

After changes:
```yaml
apiVersion: helm.m.crossplane.io/v1beta1
kind: Release
metadata:
  annotations:
    crossplane.io/external-create-pending: "2026-06-13T14:27:57Z"
    crossplane.io/external-create-succeeded: "2026-06-13T14:27:59Z"
    crossplane.io/external-name: node-feature-discovery
  creationTimestamp: "2026-06-13T14:27:57Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 2
  name: node-feature-discovery
  namespace: crossplane-system
  resourceVersion: "962"
  uid: f5e68e30-cf23-4a57-b51b-a9a2461800ec
spec:
  forProvider:
    chart:
      name: node-feature-discovery
      pullSecretRef:
        name: ""
      repository: https://kubernetes-sigs.github.io/node-feature-discovery/charts
      version: 0.18.3
    namespace: nfd
  managementPolicies:
  - '*'
  providerConfigRef:
    kind: ClusterProviderConfig
    name: helm-provider-cluster
status:
  atProvider:
    releaseDescription: Install complete
    revision: 1
    state: deployed
  conditions:
  - lastTransitionTime: "2026-06-13T14:27:59Z"
    reason: Available
    status: "True"
    type: Ready
  - lastTransitionTime: "2026-06-13T14:27:59Z"
    observedGeneration: 2
    reason: ReconcileSuccess
    status: "True"
    type: Synced
  synced: true
```

[contribution process]: https://git.io/fj2m9
