### PR TITLE
Add support for configurable revision history limit

### DIFF
--- a/apis/cluster/release/v1beta1/types.go
+++ b/apis/cluster/release/v1beta1/types.go
@@ -112,6 +112,10 @@ type ReleaseParameters struct {
 	// This prevents silent adoption of unrelated resources during chart upgrades.
 	// Use this field to migrate manually-deployed Helm releases into Crossplane management.
 	TakeOwnership bool `json:"takeOwnership,omitempty"`
+	// MaxHistory limits the maximum number of revisions saved per release. Use 0 for no limit.
+	// +optional
+	// +kubebuilder:default:=20
+	MaxHistory int `json:"maxHistory,omitempty"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/apis/namespaced/release/v1beta1/types.go
+++ b/apis/namespaced/release/v1beta1/types.go
@@ -108,6 +108,10 @@ type ReleaseParameters struct {
 	// This prevents silent adoption of unrelated resources during chart upgrades.
 	// Use this field to migrate manually-deployed Helm releases into Crossplane management.
 	TakeOwnership bool `json:"takeOwnership,omitempty"`
+	// MaxHistory limits the maximum number of revisions saved per release. Use 0 for no limit.
+	// +optional
+	// +kubebuilder:default:=20
+	MaxHistory int `json:"maxHistory,omitempty"`
 }
 
 // ReleaseObservation are the observable fields of a Release.

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -595,6 +595,11 @@ spec:
                     description: InsecureSkipTLSVerify skips tls certificate checks
                       for the chart download
                     type: boolean
+                  maxHistory:
+                    default: 20
+                    description: MaxHistory limits the maximum number of revisions
+                      saved per release. Use 0 for no limit.
+                    type: integer
                   namespace:
                     description: Namespace to install the release into.
                     type: string

--- a/package/crds/helm.m.crossplane.io_releases.yaml
+++ b/package/crds/helm.m.crossplane.io_releases.yaml
@@ -168,6 +168,11 @@ spec:
                     description: InsecureSkipTLSVerify skips tls certificate checks
                       for the chart download
                     type: boolean
+                  maxHistory:
+                    default: 20
+                    description: MaxHistory limits the maximum number of revisions
+                      saved per release. Use 0 for no limit.
+                    type: integer
                   namespace:
                     description: |-
                       Namespace to install the release into.

--- a/pkg/clients/helm/args.go
+++ b/pkg/clients/helm/args.go
@@ -19,4 +19,6 @@ type Args struct {
 	// TakeOwnership ignore the check for helm annotations and take ownership
 	// of the existing resources.
 	TakeOwnership bool
+	// MaxHistory limits the maximum number of revisions saved per release. Use 0 for no limit.
+	MaxHistory int
 }

--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -42,9 +42,6 @@ import (
 
 const (
 	helmDriverSecret = "secret"
-	// releaseMaxHistory is the maximum number of entries Helm will keep in
-	// release history. We just set a reasonable default for our use case.
-	releaseMaxHistory = 20
 )
 
 // chartCache is the directory where pulled chart tarballs are stored. It is
@@ -146,6 +143,7 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	uc.InsecureSkipTLSverify = args.InsecureSkipTLSVerify
 	uc.PlainHTTP = args.PlainHTTP
 	uc.TakeOwnership = args.TakeOwnership
+	uc.MaxHistory = args.MaxHistory
 
 	uic := action.NewUninstall(actionConfig)
 	uic.Wait = args.Wait
@@ -437,7 +435,6 @@ func (hc *client) Install(release string, chart *chart.Chart, vals map[string]in
 func (hc *client) Upgrade(release string, chart *chart.Chart, vals map[string]interface{}, patches []ktype.Patch) (*release.Release, error) {
 	// Reset values so that source of truth for desired state is always the CR itself
 	hc.upgradeClient.ResetValues = true
-	hc.upgradeClient.MaxHistory = releaseMaxHistory
 
 	if len(patches) > 0 {
 		hc.upgradeClient.PostRenderer = &KustomizationRender{

--- a/pkg/controller/cluster/release/release.go
+++ b/pkg/controller/cluster/release/release.go
@@ -157,6 +157,7 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		// Only use TakeOwnership if requested AND not already used
 		// This prevents silent adoption of resources during upgrades after initial adoption
 		config.TakeOwnership = cr.Spec.ForProvider.TakeOwnership && !cr.Status.AtProvider.OwnershipTaken
+		config.MaxHistory = cr.Spec.ForProvider.MaxHistory
 	}
 }
 

--- a/pkg/controller/namespaced/release/release.go
+++ b/pkg/controller/namespaced/release/release.go
@@ -162,6 +162,7 @@ func withRelease(cr *v1beta1.Release) helmClient.ArgsApplier {
 		// Only use TakeOwnership if requested AND not already used
 		// This prevents silent adoption of resources during upgrades after initial adoption
 		config.TakeOwnership = cr.Spec.ForProvider.TakeOwnership && !cr.Status.AtProvider.OwnershipTaken
+		config.MaxHistory = cr.Spec.ForProvider.MaxHistory
 	}
 }
 


### PR DESCRIPTION
### Description of your changes

This adds a `maxHistory` field to the `Release` API that limits the number of revisions saved per release, threaded through to the Helm upgrade client. Previously the history limit was hardcoded to 20, which can accumulate a large number of release-history `Secret`s on clusters with many releases. It defaults to `20` to preserve the existing behaviour; set `0` for no limit.

This recreates and rebases @hudymi's original PR #280 onto the current Crossplane v2 layout — applying it to both the cluster (`helm.crossplane.io`) and namespaced (`helm.m.crossplane.io`) `Release` APIs, and using an idiomatic optional `json:"maxHistory,omitempty"` field. Full credit to @hudymi for the original change; opening a fresh PR since the original needed a rebase (per the maintainer's request on #280).

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Added or updated unit tests where applicable.

### How has this code been tested

- `go build ./...`, `go vet`, and the existing unit tests pass for `pkg/clients/helm` and both the cluster and namespaced release controllers.
- CRDs regenerated via `go generate` (controller-gen); `maxHistory` appears in both `Release` CRDs as an optional integer defaulting to `20`.

[contribution process]: https://github.com/crossplane/crossplane/blob/main/CONTRIBUTING.md
