### PR TITLE
fix(client): spread variadic args in helm debug log

### DIFF
--- a/pkg/clients/helm/client.go
+++ b/pkg/clients/helm/client.go
@@ -100,7 +100,7 @@ func NewClient(log logging.Logger, restConfig *rest.Config, argAppliers ...ArgsA
 	actionConfig := new(action.Configuration)
 	// Always store helm state in the same cluster/namespace where chart is deployed
 	if err := actionConfig.Init(rg, args.Namespace, helmDriverSecret, func(format string, v ...interface{}) {
-		log.Debug(fmt.Sprintf(format, v))
+		log.Debug(fmt.Sprintf(format, v...))
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### Description of your changes

`NewClient` forwards helm's debug callback to the provider logger, but formats it with `fmt.Sprintf(format, v)` — handing the whole `[]interface{}` slice to the first verb. Any helm debug line with more than one verb comes out mangled, e.g. from #199:

```
Looks like there are no changes for [ClusterRoleBinding vc-vc1-vcluster-v-vc1] %!q(MISSING)
```

(helm logs `"Looks like there are no changes for %s %q"` — the slice lands in `%s`, `%q` gets nothing.)

This spreads the args into the format verbs (`v...`).

Fixes #199

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

`make reviewable` (generate, lint, unit tests) is green on the branch.

[contribution process]: https://github.com/crossplane/crossplane/blob/main/contributing/README.md
