### PR TITLE
fix(release): skip set if optional source missing

### DIFF
--- a/pkg/controller/cluster/release/values.go
+++ b/pkg/controller/cluster/release/values.go
@@ -77,6 +77,9 @@ func composeValuesFromSpec(ctx context.Context, kube client.Client, spec v1beta1
 		}
 
 		if v == "" {
+			if optionalValueFrom(s.ValueFrom) {
+				continue
+			}
 			return nil, errors.New(errMissingValueForSet)
 		}
 
@@ -86,6 +89,18 @@ func composeValuesFromSpec(ctx context.Context, kube client.Client, spec v1beta1
 	}
 
 	return base, nil
+}
+
+func optionalValueFrom(vf *v1beta1.ValueFromSource) bool {
+	switch {
+	case vf == nil:
+		return false
+	case vf.SecretKeyRef != nil:
+		return vf.SecretKeyRef.Optional
+	case vf.ConfigMapKeyRef != nil:
+		return vf.ConfigMapKeyRef.Optional
+	}
+	return false
 }
 
 // Copied from helm cli

--- a/pkg/controller/cluster/release/values_test.go
+++ b/pkg/controller/cluster/release/values_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-helm/apis/cluster/release/v1beta1"
@@ -315,6 +317,126 @@ keyB:
 				err: errors.Wrap(errors.Wrap(errors.Wrap(errBoom, fmt.Sprintf(errFailedToGetSecret, testNamespace)),
 					errFailedToGetDataFromSecretRef),
 					errFailedToGetValueFromSource),
+			},
+		},
+		"SetSkippedWhenOptionalValueFromSecretMissing": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+					},
+				},
+				spec: v1beta1.ValuesSpec{
+					Values: runtime.RawExtension{
+						Raw: []byte(`
+keyA: valA
+`),
+					},
+					Set: []v1beta1.SetVal{
+						{
+							Name: "keyA",
+							ValueFrom: &v1beta1.ValueFromSource{
+								SecretKeyRef: &v1beta1.DataKeySelector{
+									NamespacedName: v1beta1.NamespacedName{
+										Name:      testSecretName,
+										Namespace: testNamespace,
+									},
+									Key:      "keyA",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: map[string]interface{}{
+					"keyA": "valA",
+				},
+				err: nil,
+			},
+		},
+		"SetSkippedWhenOptionalValueFromKeyMissing": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						if key.Name == testSecretName && key.Namespace == testNamespace {
+							s := corev1.Secret{
+								Data: map[string][]byte{
+									"otherKey": []byte("valY"),
+								},
+							}
+							*obj.(*corev1.Secret) = s
+							return nil
+						}
+						return errBoom
+					},
+				},
+				spec: v1beta1.ValuesSpec{
+					Values: runtime.RawExtension{
+						Raw: []byte(`
+keyA: valA
+`),
+					},
+					Set: []v1beta1.SetVal{
+						{
+							Name: "keyA",
+							ValueFrom: &v1beta1.ValueFromSource{
+								SecretKeyRef: &v1beta1.DataKeySelector{
+									NamespacedName: v1beta1.NamespacedName{
+										Name:      testSecretName,
+										Namespace: testNamespace,
+									},
+									Key:      "keyA",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: map[string]interface{}{
+					"keyA": "valA",
+				},
+				err: nil,
+			},
+		},
+		"SetSkippedWhenOptionalValueFromConfigMapMissing": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+					},
+				},
+				spec: v1beta1.ValuesSpec{
+					Values: runtime.RawExtension{
+						Raw: []byte(`
+keyA: valA
+`),
+					},
+					Set: []v1beta1.SetVal{
+						{
+							Name: "keyA",
+							ValueFrom: &v1beta1.ValueFromSource{
+								ConfigMapKeyRef: &v1beta1.DataKeySelector{
+									NamespacedName: v1beta1.NamespacedName{
+										Name:      testCMName,
+										Namespace: testNamespace,
+									},
+									Key:      "keyA",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: map[string]interface{}{
+					"keyA": "valA",
+				},
+				err: nil,
 			},
 		},
 	}

--- a/pkg/controller/namespaced/release/values.go
+++ b/pkg/controller/namespaced/release/values.go
@@ -77,6 +77,9 @@ func composeValuesFromSpec(ctx context.Context, kube client.Client, spec v1beta1
 		}
 
 		if v == "" {
+			if optionalValueFrom(s.ValueFrom) {
+				continue
+			}
 			return nil, errors.New(errMissingValueForSet)
 		}
 
@@ -86,6 +89,18 @@ func composeValuesFromSpec(ctx context.Context, kube client.Client, spec v1beta1
 	}
 
 	return base, nil
+}
+
+func optionalValueFrom(vf *v1beta1.ValueFromSource) bool {
+	switch {
+	case vf == nil:
+		return false
+	case vf.SecretKeyRef != nil:
+		return vf.SecretKeyRef.Optional
+	case vf.ConfigMapKeyRef != nil:
+		return vf.ConfigMapKeyRef.Optional
+	}
+	return false
 }
 
 // Copied from helm cli

--- a/pkg/controller/namespaced/release/values_test.go
+++ b/pkg/controller/namespaced/release/values_test.go
@@ -9,7 +9,9 @@ import (
 	"github.com/crossplane/crossplane-runtime/v2/pkg/test"
 	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/crossplane-contrib/provider-helm/apis/namespaced/release/v1beta1"
@@ -300,6 +302,117 @@ keyB:
 				err: errors.Wrap(errors.Wrap(errors.Wrap(errBoom, fmt.Sprintf(errFailedToGetSecret, testNamespace)),
 					errFailedToGetDataFromSecretRef),
 					errFailedToGetValueFromSource),
+			},
+		},
+		"SetSkippedWhenOptionalValueFromSecretMissing": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, key.Name)
+					},
+				},
+				spec: v1beta1.ValuesSpec{
+					Values: runtime.RawExtension{
+						Raw: []byte(`
+keyA: valA
+`),
+					},
+					Set: []v1beta1.SetVal{
+						{
+							Name: "keyA",
+							ValueFrom: &v1beta1.ValueFromSource{
+								SecretKeyRef: &v1beta1.DataKeySelector{
+									Name:     testSecretName,
+									Key:      "keyA",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: map[string]interface{}{
+					"keyA": "valA",
+				},
+				err: nil,
+			},
+		},
+		"SetSkippedWhenOptionalValueFromKeyMissing": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						if key.Name == testSecretName && key.Namespace == testNamespace {
+							s := corev1.Secret{
+								Data: map[string][]byte{
+									"otherKey": []byte("valY"),
+								},
+							}
+							*obj.(*corev1.Secret) = s
+							return nil
+						}
+						return errBoom
+					},
+				},
+				spec: v1beta1.ValuesSpec{
+					Values: runtime.RawExtension{
+						Raw: []byte(`
+keyA: valA
+`),
+					},
+					Set: []v1beta1.SetVal{
+						{
+							Name: "keyA",
+							ValueFrom: &v1beta1.ValueFromSource{
+								SecretKeyRef: &v1beta1.DataKeySelector{
+									Name:     testSecretName,
+									Key:      "keyA",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: map[string]interface{}{
+					"keyA": "valA",
+				},
+				err: nil,
+			},
+		},
+		"SetSkippedWhenOptionalValueFromConfigMapMissing": {
+			args: args{
+				kube: &test.MockClient{
+					MockGet: func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return kerrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
+					},
+				},
+				spec: v1beta1.ValuesSpec{
+					Values: runtime.RawExtension{
+						Raw: []byte(`
+keyA: valA
+`),
+					},
+					Set: []v1beta1.SetVal{
+						{
+							Name: "keyA",
+							ValueFrom: &v1beta1.ValueFromSource{
+								ConfigMapKeyRef: &v1beta1.DataKeySelector{
+									Name:     testCMName,
+									Key:      "keyA",
+									Optional: true,
+								},
+							},
+						},
+					},
+				},
+			},
+			want: want{
+				out: map[string]interface{}{
+					"keyA": "valA",
+				},
+				err: nil,
 			},
 		},
 	}


### PR DESCRIPTION
### Description of your changes

A `set` entry whose `valueFrom` points at an `optional: true` secret/configmap ref still failed the whole values composition with `missing value for --set` when the source (or its key) was missing — making `optional` meaningless for `set`.

`getDataValueFromSource` already resolves optional+missing sources to an empty value; `composeValuesFromSpec` now skips such `set` entries instead of erroring. Behavior is unchanged for non-optional refs (still an error) and for a `set` with neither `value` nor `valueFrom` (still `missing value for --set`). Applied to both the cluster-scoped and namespaced controllers.

Fixes #265

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

New table-test cases in both scopes — optional secret missing, optional key missing, optional configmap missing — all reproduce the `missing value for --set` failure on the previous code and pass with the fix. `make reviewable` (generate, lint, unit tests) is green.

[contribution process]: https://github.com/crossplane/crossplane/blob/main/contributing/README.md
