### PR TITLE
Apply MR API versioning policy, deprecate `v1alpha1`, add `Release` conversion, lint examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,28 @@ jobs:
       - name: Check Diff
         run: make check-diff
 
+  example-lint:
+    runs-on: ubuntu-latest
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Lint Example Manifests
+        run: make example-lint
+
   unit-tests:
     runs-on: ubuntu-latest
     needs: detect-noop

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,34 @@ local-deploy: build controlplane.up local.xpkg.deploy.provider.$(PROJECT_NAME)
 
 e2e: local-deploy uptest
 
+KUBECTL_VALIDATE_VERSION = v0.0.4
+KUBECTL_VALIDATE := $(TOOLS_HOST_DIR)/kubectl-validate-$(KUBECTL_VALIDATE_VERSION)
+
+$(KUBECTL_VALIDATE):
+	@$(INFO) installing kubectl-validate $(KUBECTL_VALIDATE_VERSION)
+	@mkdir -p $(TOOLS_HOST_DIR)
+	@GOBIN=$(abspath $(TOOLS_HOST_DIR)) go install sigs.k8s.io/kubectl-validate@$(KUBECTL_VALIDATE_VERSION)
+	@mv $(TOOLS_HOST_DIR)/kubectl-validate $@
+	@$(OK) installed kubectl-validate $(KUBECTL_VALIDATE_VERSION)
+
+# example-lint validates our example manifests against the CRDs we ship. A
+# few examples are intentionally excluded because they aren't provider-helm's
+# own CRDs and kubectl-validate has no schema for them: examples/cluster/in-composition/*
+# demonstrates using a Release inside a Composition via a fictional
+# example.crossplane.io XRD, and provider-incluster.yaml is a Crossplane
+# Provider package install manifest (pkg.crossplane.io).
+example-lint: $(KUBECTL_VALIDATE)
+	@$(INFO) linting example manifests
+	@failed=0; \
+	for dir in examples/cluster examples/namespaced; do \
+		files=$$(find $$dir -name '*.yaml' \
+			-not -path 'examples/cluster/in-composition/*' \
+			-not -path 'examples/cluster/provider-config/provider-incluster.yaml' \
+			-not -path 'examples/namespaced/provider-config/provider-incluster.yaml'); \
+		$(KUBECTL_VALIDATE) $$files --local-crds package/crds || failed=1; \
+	done; \
+	[ $$failed -eq 0 ] && $(OK) linted example manifests || $(FAIL)
+
 # Update the submodules, such as the common build scripts.
 submodules:
 	@git submodule sync
@@ -165,4 +193,4 @@ go.cachedir:
 go.mod.cachedir:
 	@go env GOMODCACHE
 
-.PHONY: cobertura submodules fallthrough test-integration run manifests go.cachedir go.mod.cachedir
+.PHONY: cobertura submodules fallthrough test-integration run manifests go.cachedir go.mod.cachedir example-lint

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,12 @@ XPKG_REG_ORGS ?= xpkg.upbound.io/crossplane-contrib index.docker.io/crossplaneco
 # inferred.
 XPKG_REG_ORGS_NO_PROMOTE ?= xpkg.upbound.io/crossplane-contrib
 XPKGS = provider-helm
+# The conversion webhook config for our multi-version CRDs is injected into
+# $(OUTPUT_DIR)/package by the kustomize-crds target below, so we build the
+# package from there instead of from the repo's package/ directory. The
+# kustomize config files themselves aren't part of the package.
+XPKG_DIR = $(OUTPUT_DIR)/package
+XPKG_IGNORE = kustomize/kustomization.yaml,kustomize/splitter.yaml,kustomize/webhook.yaml
 -include build/makelib/xpkg.mk
 
 # We force image building to happen prior to xpkg build so that we ensure image
@@ -119,6 +125,22 @@ submodules:
 # We must ensure up is installed in tool cache prior to build as including the
 # k8s_tools machinery prior to the xpkg machinery sets UP to point to tool cache.
 build.init: $(CROSSPLANE_CLI)
+
+build.init: kustomize-crds
+
+# Injects the conversion webhook configuration into the CRDs that are served
+# in more than one version. This can't be done with controller-gen, so we
+# patch it in with kustomize, following the same approach kubebuilder uses.
+# Can be removed once we drop support for the deprecated v1alpha1 APIs.
+kustomize-crds: output.init $(KUSTOMIZE) $(YQ)
+	@$(INFO) Kustomizing CRDs
+	@rm -fr $(OUTPUT_DIR)/package || $(FAIL)
+	@cp -R package $(OUTPUT_DIR) || $(FAIL)
+	@export YQ=$(YQ) && \
+		XDG_CONFIG_HOME=$(PWD)/package $(KUSTOMIZE) build --enable-alpha-plugins --load-restrictor=LoadRestrictionsNone $(OUTPUT_DIR)/package/kustomize -o $(OUTPUT_DIR)/package/crds.yaml || $(FAIL)
+	@$(OK) Kustomizing CRDs
+
+.PHONY: kustomize-crds
 
 # This is for running out-of-cluster locally, and is for convenience. Running
 # this make target will print out the command which was used. For more control,

--- a/apis/cluster/release/v1alpha1/conversion.go
+++ b/apis/cluster/release/v1alpha1/conversion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Crossplane Authors.
+Copyright 2026 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apis/cluster/release/v1alpha1/conversion.go
+++ b/apis/cluster/release/v1alpha1/conversion.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"encoding/json"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/conversion"
+
+	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
+
+	"github.com/crossplane-contrib/provider-helm/apis/cluster/release/v1beta1"
+)
+
+// ConversionDataAnnotationKey stashes the v1beta1 fields that have no
+// v1alpha1 equivalent, so that a write made through the deprecated v1alpha1
+// API doesn't silently erase them. ConvertFrom sets it; ConvertTo consumes
+// and strips it.
+const ConversionDataAnnotationKey = "helm.crossplane.io/release-conversion-data"
+
+// conversionData holds the v1beta1 Release fields that v1alpha1 has no way
+// to represent.
+type conversionData struct {
+	ChartURL              string                     `json:"chartURL,omitempty"`
+	ChartDigest           string                     `json:"chartDigest,omitempty"`
+	SkipCreateNamespace   bool                       `json:"skipCreateNamespace,omitempty"`
+	WaitTimeout           *metav1.Duration           `json:"waitTimeout,omitempty"`
+	SkipCRDs              bool                       `json:"skipCRDs,omitempty"`
+	InsecureSkipTLSVerify bool                       `json:"insecureSkipTLSVerify,omitempty"`
+	PlainHTTP             bool                       `json:"plainHTTP,omitempty"`
+	CABundle              *v1beta1.ValueFromSource   `json:"caBundle,omitempty"`
+	TakeOwnership         bool                       `json:"takeOwnership,omitempty"`
+	MaxHistory            int                        `json:"maxHistory,omitempty"`
+	SSAForceConflicts     bool                       `json:"ssaForceConflicts,omitempty"`
+	ConnectionDetails     []v1beta1.ConnectionDetail `json:"connectionDetails,omitempty"`
+	ObservedDigest        string                     `json:"observedDigest,omitempty"`
+	ObservedVersion       string                     `json:"observedVersion,omitempty"`
+	OwnershipTaken        bool                       `json:"ownershipTaken,omitempty"`
+}
+
+// ConvertTo converts this Release to the Hub version (v1beta1). Fields that
+// exist in both versions are copied via an unstructured round-trip instead
+// of a hand-maintained field-by-field mapping. v1beta1-only fields are then
+// restored from the ConversionDataAnnotationKey annotation, if ConvertFrom
+// previously stashed one there (e.g. this object was read, and is now being
+// written back, through the deprecated v1alpha1 API) — without this, that
+// round trip would silently reset them to their zero value.
+func (src *Release) ConvertTo(dstRaw conversion.Hub) error {
+	dst := dstRaw.(*v1beta1.Release)
+	gvk := dst.GetObjectKind().GroupVersionKind()
+
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(src)
+	if err != nil {
+		return errors.Wrap(err, "cannot convert Release v1alpha1 to unstructured")
+	}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u, dst); err != nil {
+		return errors.Wrap(err, "cannot convert unstructured to Release v1beta1")
+	}
+	dst.GetObjectKind().SetGroupVersionKind(gvk)
+
+	raw, ok := dst.Annotations[ConversionDataAnnotationKey]
+	if !ok {
+		return nil
+	}
+	delete(dst.Annotations, ConversionDataAnnotationKey)
+
+	cd := conversionData{}
+	if err := json.Unmarshal([]byte(raw), &cd); err != nil {
+		return errors.Wrap(err, "cannot unmarshal Release conversion data annotation")
+	}
+
+	dst.Spec.ForProvider.Chart.URL = cd.ChartURL
+	dst.Spec.ForProvider.Chart.Digest = cd.ChartDigest
+	dst.Spec.ForProvider.SkipCreateNamespace = cd.SkipCreateNamespace
+	dst.Spec.ForProvider.WaitTimeout = cd.WaitTimeout
+	dst.Spec.ForProvider.SkipCRDs = cd.SkipCRDs
+	dst.Spec.ForProvider.InsecureSkipTLSVerify = cd.InsecureSkipTLSVerify
+	dst.Spec.ForProvider.PlainHTTP = cd.PlainHTTP
+	dst.Spec.ForProvider.CABundle = cd.CABundle
+	dst.Spec.ForProvider.TakeOwnership = cd.TakeOwnership
+	dst.Spec.ForProvider.MaxHistory = cd.MaxHistory
+	dst.Spec.ForProvider.SSAForceConflicts = cd.SSAForceConflicts
+	dst.Spec.ConnectionDetails = cd.ConnectionDetails
+	dst.Status.AtProvider.Digest = cd.ObservedDigest
+	dst.Status.AtProvider.Version = cd.ObservedVersion
+	dst.Status.AtProvider.OwnershipTaken = cd.OwnershipTaken
+
+	return nil
+}
+
+// ConvertFrom converts from the Hub version (v1beta1) to this version, via
+// the same unstructured round-trip as ConvertTo. Fields v1alpha1 has no
+// equivalent for (e.g. chart URL/digest, SSAForceConflicts, ConnectionDetails)
+// are stashed in the ConversionDataAnnotationKey annotation instead of being
+// silently dropped, so that ConvertTo can restore them if this object is
+// later written back through v1alpha1.
+func (dst *Release) ConvertFrom(srcRaw conversion.Hub) error {
+	src := srcRaw.(*v1beta1.Release)
+	gvk := dst.GetObjectKind().GroupVersionKind()
+
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(src)
+	if err != nil {
+		return errors.Wrap(err, "cannot convert Release v1beta1 to unstructured")
+	}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u, dst); err != nil {
+		return errors.Wrap(err, "cannot convert unstructured to Release v1alpha1")
+	}
+	dst.GetObjectKind().SetGroupVersionKind(gvk)
+
+	cd := conversionData{
+		ChartURL:              src.Spec.ForProvider.Chart.URL,
+		ChartDigest:           src.Spec.ForProvider.Chart.Digest,
+		SkipCreateNamespace:   src.Spec.ForProvider.SkipCreateNamespace,
+		WaitTimeout:           src.Spec.ForProvider.WaitTimeout,
+		SkipCRDs:              src.Spec.ForProvider.SkipCRDs,
+		InsecureSkipTLSVerify: src.Spec.ForProvider.InsecureSkipTLSVerify,
+		PlainHTTP:             src.Spec.ForProvider.PlainHTTP,
+		CABundle:              src.Spec.ForProvider.CABundle,
+		TakeOwnership:         src.Spec.ForProvider.TakeOwnership,
+		MaxHistory:            src.Spec.ForProvider.MaxHistory,
+		SSAForceConflicts:     src.Spec.ForProvider.SSAForceConflicts,
+		ConnectionDetails:     src.Spec.ConnectionDetails,
+		ObservedDigest:        src.Status.AtProvider.Digest,
+		ObservedVersion:       src.Status.AtProvider.Version,
+		OwnershipTaken:        src.Status.AtProvider.OwnershipTaken,
+	}
+
+	raw, err := json.Marshal(cd)
+	if err != nil {
+		return errors.Wrap(err, "cannot marshal Release conversion data annotation")
+	}
+	// Every field is omitempty, so "{}" means there's nothing v1alpha1-only
+	// to preserve — leave the object without the annotation instead of
+	// churning it on every object that never used a v1beta1-only field.
+	if string(raw) == "{}" {
+		return nil
+	}
+	if dst.Annotations == nil {
+		dst.Annotations = map[string]string{}
+	}
+	dst.Annotations[ConversionDataAnnotationKey] = string(raw)
+
+	return nil
+}

--- a/apis/cluster/release/v1alpha1/conversion_test.go
+++ b/apis/cluster/release/v1alpha1/conversion_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Crossplane Authors.
+Copyright 2026 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apis/cluster/release/v1alpha1/conversion_test.go
+++ b/apis/cluster/release/v1alpha1/conversion_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/randfill"
+
+	"github.com/crossplane-contrib/provider-helm/apis/cluster/release/v1alpha1"
+	"github.com/crossplane-contrib/provider-helm/apis/cluster/release/v1beta1"
+)
+
+// rawExtensionFuzzer fills only the .Raw bytes of a runtime.RawExtension,
+// leaving .Object nil (an interface field randfill can't fill on its own).
+// Raw bytes are all that ever actually round-trips through JSON in practice.
+func rawExtensionFuzzer(r *runtime.RawExtension, c randfill.Continue) {
+	r.Object = nil
+	r.Raw = []byte(fmt.Sprintf(`{"k%d":"v%d"}`, c.Intn(1000), c.Intn(1000)))
+}
+
+func newFiller(nilChance float64) *randfill.Filler {
+	return randfill.New().NilChance(nilChance).NumElements(0, 3).Funcs(rawExtensionFuzzer)
+}
+
+// cmpOpts treats nil and empty slices/maps as equal, and ignores the
+// conversion-data annotation: its presence/exact value is conversion
+// bookkeeping, not part of the round-tripped object's real content.
+var cmpOpts = []cmp.Option{
+	cmpopts.EquateEmpty(),
+	cmpopts.IgnoreMapEntries(func(k, _ string) bool {
+		return k == v1alpha1.ConversionDataAnnotationKey
+	}),
+}
+
+// TestConvertSpokeHubSpoke verifies that a v1alpha1 (spoke) Release survives
+// a round trip through v1beta1 (hub) and back unchanged.
+func TestConvertSpokeHubSpoke(t *testing.T) {
+	for _, nilChance := range []float64{0, 0.3} {
+		f := newFiller(nilChance)
+		for i := 0; i < 200; i++ {
+			src := &v1alpha1.Release{}
+			f.Fill(src)
+			src.TypeMeta = metav1.TypeMeta{}
+			src.ManagedFields = nil // generic k8s metadata quirk, unrelated to our conversion logic
+
+			hub := &v1beta1.Release{}
+			if err := src.ConvertTo(hub); err != nil {
+				t.Fatalf("nilChance %v, iteration %d: ConvertTo: %v", nilChance, i, err)
+			}
+
+			final := &v1alpha1.Release{}
+			if err := final.ConvertFrom(hub); err != nil {
+				t.Fatalf("nilChance %v, iteration %d: ConvertFrom: %v", nilChance, i, err)
+			}
+
+			if diff := cmp.Diff(src, final, cmpOpts...); diff != "" {
+				t.Fatalf("nilChance %v, iteration %d: spoke->hub->spoke round-trip diff (-want +got):\n%s", nilChance, i, diff)
+			}
+		}
+	}
+}
+
+// TestConvertHubSpokeHub verifies that a v1beta1 (hub) Release survives a
+// round trip through v1alpha1 (spoke) and back unchanged, proving that the
+// conversion-data annotation correctly preserves fields v1alpha1 has no
+// representation for.
+func TestConvertHubSpokeHub(t *testing.T) {
+	for _, nilChance := range []float64{0, 0.3} {
+		f := newFiller(nilChance)
+		for i := 0; i < 200; i++ {
+			src := &v1beta1.Release{}
+			f.Fill(src)
+			src.TypeMeta = metav1.TypeMeta{}
+			src.ManagedFields = nil // generic k8s metadata quirk, unrelated to our conversion logic
+
+			spoke := &v1alpha1.Release{}
+			if err := spoke.ConvertFrom(src); err != nil {
+				t.Fatalf("nilChance %v, iteration %d: ConvertFrom: %v", nilChance, i, err)
+			}
+
+			final := &v1beta1.Release{}
+			if err := spoke.ConvertTo(final); err != nil {
+				t.Fatalf("nilChance %v, iteration %d: ConvertTo: %v", nilChance, i, err)
+			}
+
+			if diff := cmp.Diff(src, final, cmpOpts...); diff != "" {
+				t.Fatalf("nilChance %v, iteration %d: hub->spoke->hub round-trip diff (-want +got):\n%s", nilChance, i, diff)
+			}
+		}
+	}
+}

--- a/apis/cluster/release/v1alpha1/types.go
+++ b/apis/cluster/release/v1alpha1/types.go
@@ -113,6 +113,9 @@ type ReleaseStatus struct {
 // +kubebuilder:printcolumn:name="DESCRIPTION",type="string",JSONPath=".status.atProvider.releaseDescription"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,helm}
+// +kubebuilder:deprecatedversion
+//
+// Deprecated: v1alpha1.Release is deprecated in favor of v1beta1.Release.
 type Release struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/cluster/release/v1beta1/conversion.go
+++ b/apis/cluster/release/v1beta1/conversion.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 The Crossplane Authors.
+Copyright 2026 The Crossplane Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/apis/cluster/release/v1beta1/conversion.go
+++ b/apis/cluster/release/v1beta1/conversion.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2025 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+// Hub marks this type as a conversion hub.
+func (r *Release) Hub() {}

--- a/apis/cluster/v1alpha1/types.go
+++ b/apis/cluster/v1alpha1/types.go
@@ -73,6 +73,9 @@ type ProviderConfigStatus struct {
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentialsSecretRef.name",priority=1
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,helm}
+// +kubebuilder:deprecatedversion
+//
+// Deprecated: v1alpha1.ProviderConfig is deprecated in favor of v1beta1.ProviderConfig.
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -98,6 +101,9 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
 // +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,helm}
+// +kubebuilder:deprecatedversion
+//
+// Deprecated: v1alpha1.ProviderConfigUsage is deprecated in favor of v1beta1.ProviderConfigUsage.
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -61,11 +61,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	clusterapis "github.com/crossplane-contrib/provider-helm/apis/cluster"
+	releasev1alpha1cluster "github.com/crossplane-contrib/provider-helm/apis/cluster/release/v1alpha1"
 	namespacedapis "github.com/crossplane-contrib/provider-helm/apis/namespaced"
 	"github.com/crossplane-contrib/provider-helm/internal/bootcheck"
 	clustercontroller "github.com/crossplane-contrib/provider-helm/pkg/controller/cluster"
 	namespacedcontroller "github.com/crossplane-contrib/provider-helm/pkg/controller/namespaced"
 	"github.com/crossplane-contrib/provider-helm/pkg/version"
+)
+
+const (
+	// webhookTLSCertDirEnvVar is set by older Crossplane versions.
+	webhookTLSCertDirEnvVar = "WEBHOOK_TLS_CERT_DIR"
+	// tlsServerCertDirEnvVar is set by newer Crossplane versions.
+	tlsServerCertDirEnvVar = "TLS_SERVER_CERTS_DIR"
+	tlsServerCertDir       = "/tls/server"
 )
 
 func init() {
@@ -119,6 +128,18 @@ func main() {
 		}
 	}
 
+	// Get the TLS certs directory from the environment variable if set. In
+	// older Crossplane versions we used WEBHOOK_TLS_CERT_DIR, in newer
+	// versions we use TLS_SERVER_CERTS_DIR. If neither are set, use the
+	// default.
+	certDir := os.Getenv(webhookTLSCertDirEnvVar)
+	if certDir == "" {
+		certDir = os.Getenv(tlsServerCertDirEnvVar)
+		if certDir == "" {
+			certDir = tlsServerCertDir
+		}
+	}
+
 	scheme := runtime.NewScheme()
 	kingpin.FatalIfError(clientgoscheme.AddToScheme(scheme), "Cannot add clientgo scheme")
 	kingpin.FatalIfError(clusterapis.AddToScheme(scheme), "Cannot add cluster-scoped Helm APIs to scheme")
@@ -137,7 +158,8 @@ func main() {
 			},
 		},
 		WebhookServer: webhook.NewServer(webhook.Options{
-			Port: *webhookPort,
+			Port:    *webhookPort,
+			CertDir: certDir,
 		}),
 		Metrics: metricsserver.Options{
 			BindAddress: *metricsBindAddress,
@@ -158,6 +180,14 @@ func main() {
 		RenewDeadline:              func() *time.Duration { d := 50 * time.Second; return &d }(),
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")
+
+	// Register the conversion webhook for the deprecated cluster-scoped
+	// Release v1alpha1 API. It doesn't matter which version of Release is
+	// used to register the "/convert" handler, so we use v1alpha1 here
+	// since it will be easy to notice and remove when we drop support for
+	// v1alpha1.
+	kingpin.FatalIfError(ctrl.NewWebhookManagedBy(mgr, &releasev1alpha1cluster.Release{}).Complete(), "Cannot create Release webhook") //nolint:staticcheck // registering conversion webhook for deprecated api
+	kingpin.FatalIfError(mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()), "Cannot add webhook server readyz checker to controller manager")
 
 	mm := managed.NewMRMetricRecorder()
 	sm := statemetrics.NewMRStateMetrics()

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	sigs.k8s.io/controller-tools v0.20.1
 	sigs.k8s.io/kustomize/api v0.21.1
 	sigs.k8s.io/kustomize/kyaml v0.21.1
+	sigs.k8s.io/randfill v1.0.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -217,6 +218,5 @@ require (
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3 // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
-	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.2 // indirect
 )

--- a/package/crds/helm.crossplane.io_providerconfigs.yaml
+++ b/package/crds/helm.crossplane.io_providerconfigs.yaml
@@ -26,11 +26,14 @@ spec:
       name: SECRET-NAME
       priority: 1
       type: string
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a Helm 'provider', i.e. a connection
-          to a particular
+        description: |-
+          A ProviderConfig configures a Helm 'provider', i.e. a connection to a particular
+
+          Deprecated: v1alpha1.ProviderConfig is deprecated in favor of v1beta1.ProviderConfig.
         properties:
           apiVersion:
             description: |-

--- a/package/crds/helm.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/helm.crossplane.io_providerconfigusages.yaml
@@ -31,10 +31,14 @@ spec:
     - jsonPath: .resourceRef.name
       name: RESOURCE-NAME
       type: string
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfigUsage indicates that a resource is using a ProviderConfig.
+        description: |-
+          A ProviderConfigUsage indicates that a resource is using a ProviderConfig.
+
+          Deprecated: v1alpha1.ProviderConfigUsage is deprecated in favor of v1beta1.ProviderConfigUsage.
         properties:
           apiVersion:
             description: |-

--- a/package/crds/helm.crossplane.io_releases.yaml
+++ b/package/crds/helm.crossplane.io_releases.yaml
@@ -46,10 +46,14 @@ spec:
     - jsonPath: .metadata.creationTimestamp
       name: AGE
       type: date
+    deprecated: true
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A Release is an example API type
+        description: |-
+          A Release is an example API type
+
+          Deprecated: v1alpha1.Release is deprecated in favor of v1beta1.Release.
         properties:
           apiVersion:
             description: |-

--- a/package/kustomize/kustomization.yaml
+++ b/package/kustomize/kustomization.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# Release is the only CRD served in more than one version, so it's the only
+# one that needs a conversion webhook. ProviderConfig and
+# ProviderConfigUsage's v1alpha1 and v1beta1 schemas are compatible enough
+# (no renamed/retyped/removed fields) that they don't need one.
+resources:
+  - ../crds/helm.crossplane.io_releases.yaml
+
+patches:
+- path: webhook.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+
+transformers:
+  - splitter.yaml

--- a/package/kustomize/kustomization.yaml
+++ b/package/kustomize/kustomization.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/package/kustomize/plugin/providers.upbound.io/splittransformer/SplitTransformer
+++ b/package/kustomize/plugin/providers.upbound.io/splittransformer/SplitTransformer
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -aeuo pipefail
+
+# SPDX-FileCopyrightText: 2024 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# skip the config directory argument
+shift
+output_dir="$1"
+
+cd "${output_dir}"
+# prepend the YAML doc separator to the stdin
+{ echo "---"; cat; } | ${YQ} --split-exp '.spec.group + "_" + .spec.names.plural + ".yaml"' -

--- a/package/kustomize/splitter.yaml
+++ b/package/kustomize/splitter.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: providers.upbound.io
+kind: SplitTransformer
+metadata:
+  name: splitter
+argsOneLiner: ../crds

--- a/package/kustomize/splitter.yaml
+++ b/package/kustomize/splitter.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
 #
 # SPDX-License-Identifier: Apache-2.0
 

--- a/package/kustomize/webhook.yaml
+++ b/package/kustomize/webhook.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: ignored
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          path: /convert
+      conversionReviewVersions:
+      - v1

--- a/package/kustomize/webhook.yaml
+++ b/package/kustomize/webhook.yaml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 The Crossplane Authors <https://crossplane.io>
+# SPDX-FileCopyrightText: 2026 The Crossplane Authors <https://crossplane.io>
 #
 # SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
### Description of your changes

### Summary

This PR starts applying our API versioning policy to provider-helm's APIs. It deprecates the legacy `v1alpha1` versions of `Release`, `ProviderConfig`, and `ProviderConfigUsage`, adds a real conversion webhook for `Release` (the only one of the three whose `v1beta1` schema actually diverges from `v1alpha1` in ways that need it), and wires up an example-manifest linter to catch schema drift going forward.

### What changed

#### Deprecation
- `Release`, `ProviderConfig`, and `ProviderConfigUsage` `v1alpha1` now carry `+kubebuilder:deprecatedversion` markers and doc comments pointing at their `v1beta1` replacements.

#### Conversion
- `Release`: `v1beta1` is the `Hub`. Shared fields are copied via an unstructured round-trip rather than a hand-maintained field list, so future additive schema changes don't silently go unhandled. Fields that exist only in `v1beta1` are stashed in a `helm.crossplane.io/release-conversion-data` annotation when converting down to `v1alpha1`, and restored when converting back up — this prevents a write made through the deprecated `v1alpha1` API from silently zeroing out fields it has no way to represent. Verified with a fuzz-based round-trip test (`conversion_test.go`) covering both directions.
- `ProviderConfig`/`ProviderConfigUsage`: deliberately no conversion webhook. Their `v1alpha1`/`v1beta1` schemas are compatible (no renamed/retyped fields) that the CRD's default strategy: None is sufficient; adding a webhook here would be pure overhead.

### Example manifest linting
- New `example-lint` Makefile target (via `kubectl-validate`) validates our example manifests against the CRDs we actually ship, and a matching `example-lint` CI job.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

Tested locally.

[contribution process]: https://git.io/fj2m9
